### PR TITLE
Add questions management pages to admin server

### DIFF
--- a/admin_server/templates/questions_edit.html
+++ b/admin_server/templates/questions_edit.html
@@ -1,0 +1,52 @@
+{% extends "base.html" %}
+{% block title %}Редактирование вопроса{% endblock %}
+{% block content %}
+
+<section class="glass" style="padding:24px;">
+  <a href="/questions" class="muted" style="font-size:13px;">← Назад к списку</a>
+  <h1 style="margin:8px 0 18px;">Редактирование вопроса</h1>
+
+  {% if error_message %}
+    <div style="margin-bottom:18px; padding:12px 16px; border-radius:12px; border:1px solid rgba(255,0,0,.25); background:rgba(255,0,0,.08); color:#ffdede;">
+      {{ error_message }}
+    </div>
+  {% endif %}
+
+  <form action="/questions/{{ detail.question.id }}/update" method="post" style="display:grid; gap:16px;">
+    <div style="display:grid; gap:12px; grid-template-columns:repeat(auto-fit, minmax(220px, 1fr)); align-items:end;">
+      <label>
+        <span class="muted" style="display:block; margin-bottom:6px;">Тест</span>
+        <select name="test_id" required>
+          {% for key, label in detail.test_choices %}
+            <option value="{{ key }}" {% if key == detail.question.test_id %}selected{% endif %}>{{ label }} ({{ key }})</option>
+          {% endfor %}
+        </select>
+      </label>
+      <label>
+        <span class="muted" style="display:block; margin-bottom:6px;">Порядковый номер</span>
+        <input type="number" name="question_index" min="1" value="{{ detail.question.question_index }}" required>
+      </label>
+      <label style="display:flex; gap:8px; align-items:center;">
+        <input type="checkbox" name="is_active" value="1" {% if detail.question.is_active %}checked{% endif %}>
+        <span>Вопрос активен</span>
+      </label>
+    </div>
+
+    <label>
+      <span class="muted" style="display:block; margin-bottom:6px;">Заголовок для списка</span>
+      <input type="text" name="title" value="{{ detail.question.title }}" placeholder="Например: Ознакомительный день" autocomplete="off">
+    </label>
+
+    <label>
+      <span class="muted" style="display:block; margin-bottom:6px;">JSON данных вопроса</span>
+      <textarea name="payload" rows="16" style="width:100%; font-family:'JetBrains Mono','Fira Code',monospace;">{{ detail.payload_json }}</textarea>
+      <span class="muted" style="font-size:12px;">Структура должна соответствовать формату, который использует бот. Для вопросов с вариантами ответов укажите поля <code>options</code> и <code>correct</code>.</span>
+    </label>
+
+    <div style="display:flex; gap:12px; justify-content:flex-end;">
+      <a class="btn" href="/questions">Отмена</a>
+      <button type="submit">Сохранить изменения</button>
+    </div>
+  </form>
+</section>
+{% endblock %}

--- a/admin_server/templates/questions_list.html
+++ b/admin_server/templates/questions_list.html
@@ -1,0 +1,80 @@
+{% extends "base.html" %}
+{% block title %}Вопросы{% endblock %}
+{% block content %}
+
+<section class="glass" style="padding:24px; margin-bottom:20px;">
+  <h1 style="margin:0 0 12px;">База вопросов</h1>
+  <p class="muted" style="margin:0; max-width:720px;">
+    Здесь собраны вопросы для всех тестов. Вы можете открыть вопрос и изменить его текст,
+    варианты ответов или структуру JSON. Изменения вступят в силу после сохранения.
+  </p>
+</section>
+
+{% if tests %}
+  {% for test in tests %}
+    <section class="glass" style="padding:18px; margin-bottom:20px;" data-tilt>
+      <header style="display:flex; align-items:center; gap:12px; margin-bottom:14px; flex-wrap:wrap;">
+        <h2 style="margin:0; font-size:20px;">{{ test.title }}</h2>
+        <span class="badge">{{ test.test_id }}</span>
+        <span class="muted" style="margin-left:auto;">{{ test.questions|length }} вопросов</span>
+      </header>
+      <div style="overflow-x:auto;">
+        <table style="width:100%; border-collapse:collapse;">
+          <thead>
+            <tr>
+              <th style="padding:10px 12px; text-align:left; width:80px;">№</th>
+              <th style="padding:10px 12px; text-align:left;">Вопрос</th>
+              <th style="padding:10px 12px; text-align:left; width:140px;">Тип</th>
+              <th style="padding:10px 12px; text-align:left; width:160px;">Последнее изменение</th>
+              <th style="padding:10px 12px; text-align:left; width:120px;">Статус</th>
+              <th style="padding:10px 12px; text-align:right; width:120px;">Действия</th>
+            </tr>
+          </thead>
+          <tbody>
+          {% for item in test.questions %}
+            <tr style="border-top:1px solid rgba(255,255,255,0.06);">
+              <td style="padding:10px 12px;">{{ item.index }}</td>
+              <td style="padding:10px 12px;">
+                <div style="font-weight:600;">{{ item.title }}</div>
+                <div class="muted" style="font-size:12px;">{{ item.prompt }}</div>
+                {% if item.options_count %}
+                  <div class="muted" style="font-size:12px; margin-top:4px;">
+                    Вариантов: {{ item.options_count }}{% if item.correct_label %}, верный: {{ item.correct_label }}{% endif %}
+                  </div>
+                {% endif %}
+              </td>
+              <td style="padding:10px 12px;">
+                {% if item.kind == 'choice' %}
+                  <span class="badge" style="display:inline-block;">Варианты</span>
+                {% else %}
+                  <span class="badge" style="display:inline-block;">Свободный ответ</span>
+                {% endif %}
+              </td>
+              <td style="padding:10px 12px;">{% if item.updated_at %}{{ fmt_utc(item.updated_at) }} UTC{% else %}—{% endif %}</td>
+              <td style="padding:10px 12px;">
+                {% if item.is_active %}
+                  <span class="badge" style="color:var(--ok); border-color:rgba(35,209,139,.35);">Активен</span>
+                {% else %}
+                  <span class="badge" style="color:var(--muted);">Скрыт</span>
+                {% endif %}
+              </td>
+              <td style="padding:10px 12px; text-align:right;">
+                <a class="btn" href="/questions/{{ item.id }}/edit">Редактировать</a>
+              </td>
+            </tr>
+          {% else %}
+            <tr>
+              <td colspan="6" style="padding:20px; text-align:center;" class="muted">Пока нет вопросов.</td>
+            </tr>
+          {% endfor %}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  {% endfor %}
+{% else %}
+  <section class="glass" style="padding:24px;">
+    <p class="muted" style="margin:0;">Вопросы ещё не добавлены.</p>
+  </section>
+{% endif %}
+{% endblock %}


### PR DESCRIPTION
## Summary
- add FastAPI views for listing, editing, and updating test questions via the admin server
- port question aggregation and update helpers from the async services module
- add dedicated templates for the questions list and edit pages

## Testing
- uvicorn admin_server.app:app --host 0.0.0.0 --port 8000
- curl -i -X POST http://127.0.0.1:8000/questions/1/update --data-urlencode 'title=Тестовый вопрос' --data-urlencode 'test_id=test2' --data-urlencode 'question_index=1' --data-urlencode 'payload={"text": "🌐 <b>Где вы будете работать большую часть времени?</b>", "options": ["🏠 Дома 100%", "🏢 В офисе 100%", "👔 80% территория / 20% Офис"], "correct": 2, "feedback": ["❌ <i>Работа дома 100%</i>? Это было бы здорово, но в нашей компании личное присутствие играет ключевую роль.", "❌ <i>Работа в офисе 100%</i>? Возможно, но наши сотрудники часто выезжают к клиентам.", "✅ <i>Верно!</i> Наши сотрудники совмещают работу на территории и в офисе."]}' --data-urlencode 'is_active=1'

------
https://chatgpt.com/codex/tasks/task_e_68d7b1fad0788333b639116ad7b84407