### PR TITLE
Fix admin_server package import

### DIFF
--- a/admin_server/__init__.py
+++ b/admin_server/__init__.py
@@ -1,5 +1,31 @@
-"""Compatibility package for the legacy `admin_server` import path."""
+"""Compatibility package for the legacy :mod:`admin_server` import path.
 
-from backend.apps.admin_ui.app import app, create_app, lifespan  # noqa: F401
+The real implementation lives in :mod:`backend.apps.admin_ui.app`.  We expose
+the same public interface through :mod:`admin_server.app` and lazily re-export
+it at the package level so that ``import admin_server`` continues to behave as
+expected even in environments where optional dependencies (such as
+``fastapi``) are not installed.
+"""
+
+from __future__ import annotations
+
+from importlib import import_module
+from typing import TYPE_CHECKING
 
 __all__ = ["app", "create_app", "lifespan"]
+
+if TYPE_CHECKING:  # pragma: no cover - imported only for type checkers
+    from .app import app, create_app, lifespan
+
+
+def __getattr__(name: str):
+    if name in __all__:
+        module = import_module("admin_server.app")
+        value = getattr(module, name)
+        globals()[name] = value
+        return value
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    return sorted(set(globals()) | set(__all__))


### PR DESCRIPTION
## Summary
- lazily re-export the FastAPI app from admin_server.__init__ to avoid import-time dependency issues
- document the compatibility shim for the legacy admin_server import path

## Testing
- python - <<'PY'
import admin_server
print('imported admin_server:', admin_server.__name__)
print('__all__:', admin_server.__all__)
print('dir contains app?', 'app' in dir(admin_server))
try:
    admin_server.app
except ModuleNotFoundError as exc:
    print('lazy import failed as expected due to missing dependency:', exc.__class__.__name__)
except Exception as exc:  # guard to show actual error
    print('unexpected error:', type(exc).__name__, exc)
PY

------
https://chatgpt.com/codex/tasks/task_e_68d974bf656083339241821809b91836