### PR TITLE
Add light/dark theme toggle and refresh admin UI styling

### DIFF
--- a/backend/apps/admin_ui/templates/base.html
+++ b/backend/apps/admin_ui/templates/base.html
@@ -1,35 +1,60 @@
 <!doctype html>
-<html lang="ru">
+<html lang="ru" data-theme="dark">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>{% block title %}Админка{% endblock %} · TG Bot Admin</title>
   <link rel="icon" href="/static/favicon.ico">
+  <script>
+    (function () {
+      var storageKey = "tg-admin-theme";
+      try {
+        var stored = window.localStorage.getItem(storageKey);
+        var prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+        var theme = stored || (prefersDark ? "dark" : "light");
+        document.documentElement.dataset.theme = theme;
+        document.documentElement.style.colorScheme = theme;
+      } catch (err) {
+        document.documentElement.dataset.theme = document.documentElement.dataset.theme || "dark";
+        document.documentElement.style.colorScheme = document.documentElement.dataset.theme;
+      }
+    })();
+  </script>
   <style>
-  /* ===== Liquid Glass v2 (Three-Layer, minimal motion) ===== */
   :root {
+    color-scheme: dark;
     /* base palette */
     --bg: #0b0e13;
     --fg: #e9eef6;
+    --fg-strong: #ffffff;
     --muted: #aab3c2;
 
     /* accents */
     --accent: #69b7ff;
     --accent-2: #b889ff;
 
+    /* halo + background */
+    --bg-gradient: radial-gradient(1200px 800px at 10% 0%, rgba(105,183,255,.10), transparent 60%),
+                    radial-gradient(1200px 900px at 100% 100%, rgba(184,137,255,.10), transparent 60%),
+                    linear-gradient(180deg, #0b0e13 0%, #0d1118 100%);
+    --halo-gradient: radial-gradient(40% 40% at 10% 0%, rgba(105,183,255,.16), transparent 60%),
+                     radial-gradient(45% 45% at 90% 85%, rgba(184,137,255,.16), transparent 62%),
+                     radial-gradient(35% 35% at 65% 35%, rgba(35,209,139,.16), transparent 65%);
+
     /* glass tokens */
-    --glass-tint: rgba(255, 255, 255, 0.06);     /* base transmission */
-    --glass-stroke: rgba(255, 255, 255, 0.14);   /* outer edge */
-    --glass-inner: rgba(0, 0, 0, 0.25);          /* inner depth tint */
-    --glass-top: rgba(255, 255, 255, 0.22);      /* top optical layer */
-    --glass-bottom: rgba(0, 0, 0, 0.18);         /* bottom absorption */
-    --specular: rgba(255, 255, 255, 0.55);       /* sharp highlight lines */
-    --edge-light: rgba(255, 255, 255, 0.35);     /* hairline edge light */
-    --edge-shadow: rgba(0, 0, 0, 0.45);          /* hairline edge shadow */
-    --ring: #62a8ff;
+    --glass-tint: rgba(255, 255, 255, 0.06);
+    --glass-stroke: rgba(255, 255, 255, 0.14);
+    --glass-inner: rgba(0, 0, 0, 0.25);
+    --glass-top: rgba(255, 255, 255, 0.22);
+    --glass-bottom: rgba(0, 0, 0, 0.18);
+    --specular: rgba(255, 255, 255, 0.55);
+    --edge-light: rgba(255, 255, 255, 0.35);
+    --edge-shadow: rgba(0, 0, 0, 0.45);
 
     /* states */
-    --ok: #23d18b;  --warn: #ffd166;  --bad: #ff6b6b;
+    --ok: #23d18b;
+    --warn: #ffd166;
+    --bad: #ff6b6b;
 
     /* elevation */
     --shadow-1: 0 1px 1px rgba(0,0,0,.25), 0 2px 6px rgba(0,0,0,.22);
@@ -37,31 +62,84 @@
     --shadow-3: 0 16px 40px rgba(0,0,0,.45), inset 0 1px 0 rgba(255,255,255,.06);
 
     /* layout */
-    --radius-lg: 16px; --radius-md: 12px; --radius-sm: 10px;
+    --radius-lg: 16px;
+    --radius-md: 12px;
+    --radius-sm: 10px;
 
     /* table */
-    --row-sep: rgba(255,255,255,.06);  --border: rgba(255,255,255,.12);
+    --row-sep: rgba(255,255,255,.06);
+    --border: rgba(255,255,255,.12);
+    --table-head-bg: linear-gradient(180deg, rgba(255,255,255,.06), rgba(255,255,255,.02));
+    --table-hover: rgba(255,255,255,.05);
+
+    /* buttons & badges */
+    --btn-bg: linear-gradient(180deg, rgba(255,255,255,.10), rgba(255,255,255,.02));
+    --btn-bg-hover: linear-gradient(180deg, rgba(255,255,255,.14), rgba(255,255,255,.04));
+    --btn-shadow: var(--shadow-1), inset 0 1px 0 rgba(255,255,255,.06);
+    --badge-bg: rgba(255,255,255,.08);
+    --badge-border: var(--glass-stroke);
+    --badge-fg: var(--muted);
+    --nav-active-bg: rgba(255,255,255,.08);
 
     /* optics */
-    --blur: 16px;             /* base blur for panes */
-    --sat: 1.35;              /* base saturation */
-    --bright: 1.02;           /* base brightness to lift content */
+    --blur: 16px;
+    --sat: 1.35;
+    --bright: 1.02;
+
+    /* form controls */
+    --field-bg: rgba(12,14,19,.65);
+    --field-border: var(--glass-stroke);
+    --field-shadow: inset 0 1px 0 rgba(255,255,255,.05);
+
+    /* typography */
+    --brand-shadow: 0 1px 2px rgba(0,0,0,.35);
+  }
+
+  html[data-theme="light"] {
+    color-scheme: light;
+    --bg: #f6f7fb;
+    --fg: #0f1a2a;
+    --fg-strong: #0a1733;
+    --muted: #5b6372;
+    --accent: #2d7cff;
+    --accent-2: #6a3df5;
+    --bg-gradient: radial-gradient(1200px 840px at 0% 5%, rgba(74,118,255,.18), transparent 60%),
+                    radial-gradient(1000px 780px at 100% 100%, rgba(119,207,255,.22), transparent 55%),
+                    linear-gradient(180deg, #f6f7fb 0%, #e6ecff 100%);
+    --halo-gradient: radial-gradient(40% 40% at 8% 0%, rgba(45,124,255,.22), transparent 62%),
+                     radial-gradient(50% 45% at 92% 88%, rgba(106,61,245,.18), transparent 60%),
+                     radial-gradient(35% 35% at 65% 35%, rgba(35,209,139,.18), transparent 68%);
+    --glass-tint: rgba(255,255,255,.78);
+    --glass-stroke: rgba(12, 25, 55, 0.10);
+    --glass-inner: rgba(255,255,255,.45);
+    --glass-top: rgba(255,255,255,.92);
+    --glass-bottom: rgba(12,30,60,.08);
+    --specular: rgba(255,255,255,.85);
+    --edge-light: rgba(255,255,255,.95);
+    --edge-shadow: rgba(15,35,95,.14);
+    --shadow-1: 0 1px 1px rgba(15,35,95,.08), 0 10px 30px rgba(15,35,95,.10);
+    --shadow-2: 0 12px 30px rgba(15,35,95,.14), inset 0 1px 0 rgba(255,255,255,.45);
+    --shadow-3: 0 20px 45px rgba(15,35,95,.18), inset 0 1px 0 rgba(255,255,255,.48);
+    --row-sep: rgba(12,32,65,.10);
+    --border: rgba(12,32,65,.14);
+    --table-head-bg: linear-gradient(180deg, rgba(255,255,255,.96), rgba(255,255,255,.78));
+    --table-hover: rgba(13,41,80,.08);
+    --btn-bg: linear-gradient(180deg, rgba(255,255,255,.95), rgba(255,255,255,.78));
+    --btn-bg-hover: linear-gradient(180deg, rgba(255,255,255,1), rgba(255,255,255,.86));
+    --btn-shadow: 0 10px 26px rgba(15,35,95,.14), inset 0 1px 0 rgba(255,255,255,.85);
+    --badge-bg: rgba(45,124,255,.12);
+    --badge-border: rgba(45,124,255,.22);
+    --badge-fg: rgba(13,32,65,.76);
+    --nav-active-bg: rgba(45,124,255,.16);
+    --field-bg: rgba(255,255,255,.88);
+    --field-border: rgba(12,32,65,.16);
+    --field-shadow: inset 0 1px 0 rgba(255,255,255,.85);
+    --brand-shadow: 0 1px 0 rgba(255,255,255,.85);
   }
 
   @media (prefers-color-scheme: light) {
-    :root {
-      --bg: #f6f7fb; --fg: #0f1a2a; --muted: #5b6372;
-      --glass-tint: rgba(255,255,255,.55);
-      --glass-stroke: rgba(0,0,0,.12);
-      --glass-inner: rgba(255,255,255,.35);
-      --glass-top: rgba(255, 255, 255, 0.9);
-      --glass-bottom: rgba(0, 0, 0, 0.06);
-      --specular: rgba(255,255,255,.8);
-      --edge-light: rgba(255,255,255,.9);
-      --edge-shadow: rgba(0,0,0,.14);
-      --ring: #2d7cff;
-      --row-sep: rgba(0,0,0,.06); --border: rgba(0,0,0,.12);
-      --bright: 1.00;
+    html:not([data-theme]) {
+      color-scheme: light;
     }
   }
 
@@ -70,53 +148,56 @@
 
   body {
     margin: 0;
-    background:
-      radial-gradient(1200px 800px at 10% 0%, rgba(105,183,255,.10), transparent 60%),
-      radial-gradient(1200px 900px at 100% 100%, rgba(184,137,255,.10), transparent 60%),
-      linear-gradient(180deg, #0b0e13 0%, #0d1118 100%);
+    background: var(--bg-gradient);
     color: var(--fg);
     font: 14px/1.5 system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, "Helvetica Neue", Arial, "Apple Color Emoji","Segoe UI Emoji";
     overflow-x: hidden;
+    transition: background .35s ease, color .35s ease;
   }
 
-  /* Ambient halo (static, minimal motion) */
+  body::selection, ::selection {
+    background: color-mix(in srgb, var(--accent) 60%, transparent);
+    color: #fff;
+  }
+
   .halo {
-    position: fixed; inset: -30%; z-index: -2; pointer-events: none;
-    background:
-      radial-gradient(40% 40% at 10% 0%, rgba(105,183,255,.16), transparent 60%),
-      radial-gradient(45% 45% at 90% 85%, rgba(184,137,255,.16), transparent 62%),
-      radial-gradient(35% 35% at 65% 35%, rgba(35,209,139,.16), transparent 65%);
+    position: fixed;
+    inset: -30%;
+    z-index: -2;
+    pointer-events: none;
+    background: var(--halo-gradient);
     filter: blur(55px) saturate(1.1);
+    transition: background .35s ease;
   }
 
-  /* Fine grain overlay for glass material */
   .grain::after {
-    content: ""; position: absolute; inset: 0; pointer-events: none;
+    content: "";
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
     background-image:
       radial-gradient(rgba(255,255,255,.08) 1px, transparent 1px),
       radial-gradient(rgba(0,0,0,.08) 1px, transparent 1px);
     background-size: 2px 2px, 3px 3px;
-    mix-blend-mode: overlay; opacity: .05; border-radius: inherit;
+    mix-blend-mode: overlay;
+    opacity: .05;
+    border-radius: inherit;
   }
 
-  /* Links */
-  a { color: var(--accent); text-decoration: none; }
+  a { color: var(--accent); text-decoration: none; transition: color .2s ease; }
   a:hover { text-decoration: underline; }
 
-  /* ---- Three-layer Glass primitive ----
-     Layer model:
-     - Base: translucent tint + bottom absorption
-     - ::before: top optical highlight & hairline edge light
-     - ::after: internal vignette & edge shadow for depth
-  */
   .glass {
-    position: relative; border-radius: var(--radius-lg);
+    position: relative;
+    border-radius: var(--radius-lg);
     background: linear-gradient(180deg, var(--glass-tint), rgba(255,255,255,0.02)),
                 linear-gradient(180deg, rgba(255,255,255,0), var(--glass-bottom));
     border: 1px solid var(--glass-stroke);
     box-shadow: var(--shadow-2);
     isolation: isolate;
+    transition: background .35s ease, border-color .35s ease, box-shadow .35s ease;
   }
+
   @supports ((backdrop-filter: blur(var(--blur))) or (-webkit-backdrop-filter: blur(var(--blur)))) {
     .glass {
       backdrop-filter: blur(var(--blur)) saturate(var(--sat)) brightness(var(--bright));
@@ -124,20 +205,26 @@
       background: linear-gradient(180deg, var(--glass-tint), var(--glass-inner));
     }
   }
+
   .glass::before,
   .glass::after {
-    content: ""; position: absolute; inset: 0; border-radius: inherit; pointer-events: none;
+    content: "";
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    pointer-events: none;
   }
-  /* top optical highlight + thin specular streaks */
+
   .glass::before {
     background:
-      linear-gradient( to top left, rgba(255,255,255,.16), transparent 60%),
+      linear-gradient(to top left, rgba(255,255,255,.16), transparent 60%),
       linear-gradient( 90deg,
         transparent 0%, rgba(255,255,255,.08) 8%, transparent 14%,
         transparent 86%, rgba(255,255,255,.06) 92%, transparent 100% );
-    mix-blend-mode: screen; opacity: .8;
+    mix-blend-mode: screen;
+    opacity: .8;
   }
-  /* inner vignette + edge shadow gives curvature illusion */
+
   .glass::after {
     box-shadow: inset 0 1px 0 rgba(255,255,255,.06), inset 0 0 0 1px rgba(255,255,255,.03);
     background:
@@ -146,109 +233,324 @@
     opacity: .9;
   }
 
-  header { position: sticky; top: 0; z-index: 20; padding: 10px 16px; background: transparent; }
+  header {
+    position: sticky;
+    top: 0;
+    z-index: 20;
+    padding: 12px 16px 6px;
+    background: linear-gradient(180deg, rgba(0,0,0,.22), transparent 70%);
+  }
+
+  html[data-theme="light"] header {
+    background: linear-gradient(180deg, rgba(246,247,251,.92), rgba(246,247,251,0));
+  }
 
   .nav {
-    max-width: 1100px; margin: 0 auto; padding: 10px 12px;
-    display: flex; align-items: center; gap: 14px; border-radius: var(--radius-lg);
+    max-width: 1100px;
+    margin: 0 auto;
+    padding: 12px 16px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    flex-wrap: wrap;
+    border-radius: var(--radius-lg);
+    box-shadow: var(--shadow-1);
+    background: linear-gradient(180deg, var(--glass-tint), rgba(255,255,255,.02));
+  }
+
+  @supports ((backdrop-filter: blur(10px)) or (-webkit-backdrop-filter: blur(10px))) {
+    .nav {
+      backdrop-filter: blur(16px) saturate(1.2);
+      -webkit-backdrop-filter: blur(16px) saturate(1.2);
+    }
+  }
+
+  .nav::before,
+  .nav::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    pointer-events: none;
+  }
+
+  .nav::before {
+    background: linear-gradient(to top left, rgba(255,255,255,.14), transparent 60%);
+    mix-blend-mode: screen;
+  }
+
+  .nav::after {
+    box-shadow: inset 0 1px 0 rgba(255,255,255,.06);
+  }
+
+  .nav__section {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    flex-wrap: wrap;
+  }
+
+  .nav__section--primary {
+    gap: 14px;
+  }
+
+  .nav .brand {
+    font-weight: 800;
+    letter-spacing: .2px;
+    color: var(--fg-strong);
+    margin-right: 6px;
+    text-shadow: var(--brand-shadow);
+    font-size: 16px;
+  }
+
+  .nav a {
+    color: var(--fg);
+    opacity: .9;
+    padding: 6px 10px;
+    border-radius: 8px;
+    transition: background .2s ease, color .2s ease, opacity .2s ease;
+  }
+
+  .nav a:hover {
+    opacity: 1;
+  }
+
+  .nav a.active {
+    color: var(--fg-strong);
+    font-weight: 600;
+    background: var(--nav-active-bg);
+    box-shadow: inset 0 1px 0 rgba(255,255,255,.08);
+    text-decoration: none;
+  }
+
+  .nav__meta {
+    margin-left: auto;
+    gap: 10px;
+  }
+
+  .nav__env {
+    margin-left: 0;
+  }
+
+  .container {
+    max-width: 1100px;
+    margin: 0 auto;
+    padding: 24px 16px 32px;
+  }
+
+  .cards {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: 16px;
+    margin: 14px 0 24px;
+  }
+
+  .card {
+    border-radius: var(--radius-lg);
+    padding: 16px;
     position: relative;
+    overflow: hidden;
+    background: linear-gradient(180deg, var(--glass-tint), rgba(255,255,255,.02));
+    border: 1px solid var(--glass-stroke);
+    box-shadow: var(--shadow-2);
+    transition: transform .2s ease, box-shadow .2s ease;
   }
-  /* nav as glass */
-  .nav { border: 1px solid var(--glass-stroke); box-shadow: var(--shadow-1); }
-  .nav { background: linear-gradient(180deg, var(--glass-tint), rgba(255,255,255,.02)); }
+
   @supports ((backdrop-filter: blur(10px)) or (-webkit-backdrop-filter: blur(10px))) {
-    .nav { backdrop-filter: blur(16px) saturate(1.2); -webkit-backdrop-filter: blur(16px) saturate(1.2); }
+    .card {
+      backdrop-filter: blur(18px) saturate(1.35);
+      -webkit-backdrop-filter: blur(18px) saturate(1.35);
+    }
   }
-  .nav::before, .nav::after { content: ""; position: absolute; inset: 0; border-radius: inherit; pointer-events: none; }
-  .nav::before { background: linear-gradient( to top left, rgba(255,255,255,.14), transparent 60% ); mix-blend-mode: screen; }
-  .nav::after { box-shadow: inset 0 1px 0 rgba(255,255,255,.06); }
 
-  .nav .brand { font-weight: 800; letter-spacing: .2px; color: #fff; margin-right: 6px; text-shadow: 0 1px 2px rgba(0,0,0,.35); }
-  .nav a { color: var(--fg); opacity: .85; padding: 6px 10px; border-radius: 8px; }
-  .nav a.active { color: #fff; font-weight: 600; background: rgba(255,255,255,.06); box-shadow: inset 0 1px 0 rgba(255,255,255,.08); text-decoration: none; }
-
-  .container { max-width: 1100px; margin: 0 auto; padding: 16px; }
-
-  .cards { display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: 14px; margin: 14px 0 24px; }
-  .card { border-radius: var(--radius-lg); padding: 14px; position: relative; overflow: hidden; }
-  .card { background: linear-gradient(180deg, var(--glass-tint), rgba(255,255,255,.02)); border: 1px solid var(--glass-stroke); box-shadow: var(--shadow-2); }
-  @supports ((backdrop-filter: blur(10px)) or (-webkit-backdrop-filter: blur(10px))) {
-    .card { backdrop-filter: blur(18px) saturate(1.35); -webkit-backdrop-filter: blur(18px) saturate(1.35); }
+  .card:hover {
+    transform: translateY(-1.5px);
+    box-shadow: var(--shadow-3);
   }
-  .card::before, .card::after { content: ""; position: absolute; inset: 0; border-radius: inherit; pointer-events: none; }
-  .card::before { background: linear-gradient( 130deg, rgba(255,255,255,.12), transparent 40% ); mix-blend-mode: screen; opacity: .8; }
-  .card::after { background: radial-gradient(120% 90% at 50% 110%, rgba(0,0,0,.18), transparent 65%); box-shadow: inset 0 1px 0 rgba(255,255,255,.06); }
 
-  .card h4 { margin: 0 0 10px 0; font-size: 13px; color: var(--muted); font-weight: 700; letter-spacing: .32px; text-transform: uppercase; }
-  .card .big { font-size: 30px; font-weight: 900; letter-spacing: .2px; }
-  .badge { padding: 2px 8px; border-radius: 999px; border: 1px solid var(--glass-stroke); background: rgba(255,255,255,.06); color: var(--muted); font-size: 12px; }
+  .card::before,
+  .card::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    pointer-events: none;
+  }
+
+  .card::before {
+    background: linear-gradient(130deg, rgba(255,255,255,.12), transparent 40%);
+    mix-blend-mode: screen;
+    opacity: .8;
+  }
+
+  .card::after {
+    background: radial-gradient(120% 90% at 50% 110%, rgba(0,0,0,.18), transparent 65%);
+    box-shadow: inset 0 1px 0 rgba(255,255,255,.06);
+  }
+
+  .card h4 {
+    margin: 0 0 10px 0;
+    font-size: 13px;
+    color: var(--muted);
+    font-weight: 700;
+    letter-spacing: .32px;
+    text-transform: uppercase;
+  }
+
+  .card .big {
+    font-size: 30px;
+    font-weight: 900;
+    letter-spacing: .2px;
+  }
+
+  .badge {
+    padding: 4px 10px;
+    border-radius: 999px;
+    border: 1px solid var(--badge-border);
+    background: var(--badge-bg);
+    color: var(--badge-fg);
+    font-size: 12px;
+    letter-spacing: .3px;
+  }
+
   .muted { color: var(--muted); }
 
-  /* tables in glass */
-  table { width: 100%; border-collapse: collapse; border-radius: var(--radius-lg); overflow: hidden; }
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    border-radius: var(--radius-lg);
+    overflow: hidden;
+    background: linear-gradient(180deg, var(--glass-tint), rgba(255,255,255,.015));
+    border: 1px solid var(--glass-stroke);
+    box-shadow: var(--shadow-1);
+    transition: background .35s ease, border-color .35s ease, box-shadow .35s ease;
+  }
+
   thead th {
-    text-align: left; color: var(--muted); font-weight: 700; letter-spacing: .3px; text-transform: uppercase; font-size: 12px;
-    background: linear-gradient(180deg, rgba(255,255,255,.06), rgba(255,255,255,.02));
+    text-align: left;
+    color: var(--muted);
+    font-weight: 700;
+    letter-spacing: .3px;
+    text-transform: uppercase;
+    font-size: 12px;
+    background: var(--table-head-bg);
     border-bottom: 1px solid var(--border);
     padding: 10px 12px;
   }
-  tbody td { padding: 10px 12px; border-bottom: 1px solid var(--row-sep); }
-  tbody tr:hover { background: rgba(255,255,255,.03); }
-  table { background: linear-gradient(180deg, var(--glass-tint), rgba(255,255,255,.015)); border: 1px solid var(--glass-stroke); box-shadow: var(--shadow-1); }
-  @supports ((backdrop-filter: blur(10px)) or (-webkit-backdrop-filter: blur(10px))) {
-    table { backdrop-filter: blur(14px) saturate(1.25); -webkit-backdrop-filter: blur(14px) saturate(1.25); }
+
+  tbody td {
+    padding: 10px 12px;
+    border-bottom: 1px solid var(--row-sep);
   }
 
-  /* forms */
+  tbody tr:hover {
+    background: var(--table-hover);
+  }
+
   form label { display: inline-block; margin: 6px 12px 6px 0; }
+
   input, select, textarea {
-    background: rgba(12,14,19,.65);
+    background: var(--field-bg);
     color: var(--fg);
-    border: 1px solid var(--glass-stroke);
+    border: 1px solid var(--field-border);
     border-radius: var(--radius-md);
     padding: 8px 10px;
-    box-shadow: inset 0 1px 0 rgba(255,255,255,.05);
+    box-shadow: var(--field-shadow);
+    transition: border-color .2s ease, box-shadow .2s ease, background .2s ease;
   }
+
   input:focus, select:focus, textarea:focus {
-    outline: none; border-color: var(--ring);
-    box-shadow: 0 0 0 3px color-mix(in oklab, var(--ring) 35%, transparent);
+    outline: none;
+    border-color: var(--accent);
+    box-shadow: 0 0 0 3px color-mix(in oklab, var(--accent) 35%, transparent);
   }
 
-  /* buttons */
   button, .btn {
-    display: inline-block; padding: 9px 14px; border-radius: var(--radius-md);
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 9px 14px;
+    border-radius: var(--radius-md);
     border: 1px solid var(--glass-stroke);
-    background: linear-gradient(180deg, rgba(255,255,255,.10), rgba(255,255,255,.02));
-    color: var(--fg); cursor: pointer;
-    box-shadow: var(--shadow-1), inset 0 1px 0 rgba(255,255,255,.06);
-    transition: transform .18s ease, box-shadow .18s ease, background .18s ease;
-    position: relative; overflow: hidden;
+    background: var(--btn-bg);
+    color: var(--fg);
+    cursor: pointer;
+    box-shadow: var(--btn-shadow);
+    transition: transform .18s ease, box-shadow .18s ease, background .18s ease, color .18s ease;
+    position: relative;
+    overflow: hidden;
   }
-  button:hover, .btn:hover { background: linear-gradient(180deg, rgba(255,255,255,.14), rgba(255,255,255,.04)); transform: translateY(-.5px); box-shadow: var(--shadow-2); text-decoration: none; }
-  button:active, .btn:active { transform: translateY(0); box-shadow: var(--shadow-1); }
-  button:focus-visible, .btn:focus-visible { outline: none; box-shadow: 0 0 0 4px color-mix(in oklab, var(--ring) 32%, transparent), var(--shadow-2); }
 
-  /* reduced motion: ensure no fancy transforms */
+  button:hover, .btn:hover {
+    background: var(--btn-bg-hover);
+    transform: translateY(-.5px);
+    box-shadow: var(--shadow-2);
+    text-decoration: none;
+  }
+
+  button:active, .btn:active {
+    transform: translateY(0);
+    box-shadow: var(--shadow-1);
+  }
+
+  button:focus-visible, .btn:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 4px color-mix(in oklab, var(--accent) 32%, transparent), var(--shadow-2);
+  }
+
+  .theme-toggle {
+    border-radius: 999px;
+    font-weight: 600;
+    padding: 8px 14px;
+    background: color-mix(in srgb, var(--bg) 20%, var(--btn-bg) 80%);
+  }
+
+  .theme-toggle__icon {
+    font-size: 16px;
+    line-height: 1;
+  }
+
+  .theme-toggle__label {
+    font-size: 13px;
+  }
+
+  @media (max-width: 720px) {
+    .nav__section--primary {
+      gap: 10px;
+    }
+
+    .theme-toggle__label {
+      display: none;
+    }
+  }
+
   @media (prefers-reduced-motion: reduce) {
     * { animation: none !important; transition: none !important; }
   }
-</style>
+  </style>
 </head>
 <body>
-  <!-- Ambient halo for Liquid Glass -->
   <div aria-hidden="true" class="halo"></div>
   <header>
-    <nav class="nav">
-      <a class="brand" href="/">TG Bot Admin</a>
-      <a href="/" class="{% if request.url.path == '/' %}active{% endif %}">Дашборд</a>
-      <a href="/recruiters" class="{% if request.url.path.startswith('/recruiters') %}active{% endif %}">Рекрутёры</a>
-      {# Активен для /cities, /cities/new, /cities/<id>*, но НЕ для /cities/owners #}
-      <a href="/cities" class="{% if request.url.path == '/cities' or (request.url.path.startswith('/cities/') and not request.url.path.startswith('/cities/owners')) %}active{% endif %}">Города</a>
-      <a href="/cities/owners" class="{% if request.url.path.startswith('/cities/owners') %}active{% endif %}">Ответственные</a>
-      <a href="/slots" class="{% if request.url.path.startswith('/slots') %}active{% endif %}">Слоты</a>
-      <a href="/templates" class="{% if request.url.path.startswith('/templates') %}active{% endif %}">Шаблоны</a>
-      <a href="/questions" class="{% if request.url.path.startswith('/questions') %}active{% endif %}">Вопросы</a>
-      <span style="margin-left:auto" class="badge">{{ request.url.hostname or 'localhost' }}</span>
+    <nav class="nav glass grain" role="navigation">
+      <div class="nav__section nav__section--primary">
+        <a class="brand" href="/">TG Bot Admin</a>
+        <a href="/" class="{% if request.url.path == '/' %}active{% endif %}">Дашборд</a>
+        <a href="/recruiters" class="{% if request.url.path.startswith('/recruiters') %}active{% endif %}">Рекрутёры</a>
+        <a href="/cities" class="{% if request.url.path == '/cities' or (request.url.path.startswith('/cities/') and not request.url.path.startswith('/cities/owners')) %}active{% endif %}">Города</a>
+        <a href="/cities/owners" class="{% if request.url.path.startswith('/cities/owners') %}active{% endif %}">Ответственные</a>
+        <a href="/slots" class="{% if request.url.path.startswith('/slots') %}active{% endif %}">Слоты</a>
+        <a href="/templates" class="{% if request.url.path.startswith('/templates') %}active{% endif %}">Шаблоны</a>
+        <a href="/questions" class="{% if request.url.path.startswith('/questions') %}active{% endif %}">Вопросы</a>
+      </div>
+      <div class="nav__section nav__meta">
+        <button id="theme-toggle" class="btn theme-toggle" type="button" aria-label="Переключить тему" aria-pressed="true">
+          <span class="theme-toggle__icon" aria-hidden="true">🌙</span>
+          <span class="theme-toggle__label">Тёмная тема</span>
+        </button>
+        <span class="badge nav__env">{{ request.url.hostname or 'localhost' }}</span>
+      </div>
     </nav>
   </header>
 
@@ -257,34 +559,98 @@
   </main>
 <script>
   (function(){
-    const reduce = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    const docEl = document.documentElement;
+    const storageKey = 'tg-admin-theme';
+    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)');
+    const toggle = document.getElementById('theme-toggle');
 
-    // Tilt: opt-in via [data-tilt], very small amplitude
-    if (!reduce) {
+    function getStoredTheme() {
+      try { return window.localStorage.getItem(storageKey); } catch (err) { return null; }
+    }
+
+    function storeTheme(theme) {
+      try { window.localStorage.setItem(storageKey, theme); } catch (err) { /* noop */ }
+    }
+
+    function applyTheme(theme, persist = true) {
+      const next = theme === 'light' ? 'light' : 'dark';
+      docEl.dataset.theme = next;
+      docEl.style.colorScheme = next;
+      if (persist) {
+        storeTheme(next);
+      }
+      reflectTheme(next);
+    }
+
+    function reflectTheme(theme) {
+      if (!toggle) { return; }
+      toggle.dataset.mode = theme;
+      toggle.setAttribute('aria-pressed', theme === 'dark');
+      const icon = theme === 'dark' ? '🌙' : '🌞';
+      const label = theme === 'dark' ? 'Тёмная тема' : 'Светлая тема';
+      toggle.querySelector('.theme-toggle__icon').textContent = icon;
+      toggle.querySelector('.theme-toggle__label').textContent = label;
+      toggle.title = 'Сменить на ' + (theme === 'dark' ? 'светлую' : 'тёмную') + ' тему';
+    }
+
+    const stored = getStoredTheme();
+    const initialTheme = stored || docEl.dataset.theme || (prefersDark.matches ? 'dark' : 'light');
+    applyTheme(initialTheme, false);
+
+    if (toggle) {
+      toggle.addEventListener('click', () => {
+        const current = docEl.dataset.theme === 'light' ? 'light' : 'dark';
+        const next = current === 'dark' ? 'light' : 'dark';
+        applyTheme(next);
+      });
+    }
+
+    if (prefersDark && typeof prefersDark.addEventListener === 'function') {
+      prefersDark.addEventListener('change', event => {
+        if (!getStoredTheme()) {
+          applyTheme(event.matches ? 'dark' : 'light', false);
+        }
+      });
+    }
+
+    if (!reduceMotion) {
       const tiltTargets = Array.from(document.querySelectorAll('[data-tilt]'));
       tiltTargets.forEach(el => {
         let frame, rx = 0, ry = 0, tx = 0, ty = 0;
-        const ease = 0.12; const rect = () => el.getBoundingClientRect();
-        const max = 2; // deg
+        const ease = 0.12;
+        const rect = () => el.getBoundingClientRect();
+        const max = 2;
         const onMove = (e) => {
-          const r = rect(); const x = (e.clientX - r.left) / r.width; const y = (e.clientY - r.top) / r.height;
-          rx = (0.5 - y) * max; ry = (x - 0.5) * max; if (!frame) loop();
+          const r = rect();
+          const x = (e.clientX - r.left) / r.width;
+          const y = (e.clientY - r.top) / r.height;
+          rx = (0.5 - y) * max;
+          ry = (x - 0.5) * max;
+          if (!frame) loop();
         };
-        const onLeave = () => { rx = 0; ry = 0; if (!frame) loop(); };
+        const onLeave = () => {
+          rx = 0;
+          ry = 0;
+          if (!frame) loop();
+        };
         function loop(){
           frame = requestAnimationFrame(()=>{
-            tx += (rx - tx) * ease; ty += (ry - ty) * ease;
+            tx += (rx - tx) * ease;
+            ty += (ry - ty) * ease;
             el.style.transform = `perspective(900px) rotateX(${tx}deg) rotateY(${ty}deg)`;
-            if (Math.abs(tx - rx) > 0.01 || Math.abs(ty - ry) > 0.01) loop(); else { cancelAnimationFrame(frame); frame = null; }
+            if (Math.abs(tx - rx) > 0.01 || Math.abs(ty - ry) > 0.01) {
+              loop();
+            } else {
+              cancelAnimationFrame(frame);
+              frame = null;
+            }
           });
         }
         el.addEventListener('mousemove', onMove);
         el.addEventListener('mouseleave', onLeave);
       });
-    }
 
-    // Ripple for buttons/links with .btn (skip if reduced motion)
-    if (!reduce) {
       const rippleTargets = document.querySelectorAll('button, .btn');
       rippleTargets.forEach(btn => {
         btn.style.position = btn.style.position || 'relative';
@@ -292,14 +658,21 @@
         btn.addEventListener('click', (e) => {
           const d = Math.max(btn.clientWidth, btn.clientHeight);
           const r = document.createElement('span');
-          r.style.position = 'absolute'; r.style.width = r.style.height = d + 'px';
-          r.style.left = (e.offsetX - d/2) + 'px'; r.style.top = (e.offsetY - d/2) + 'px';
+          r.style.position = 'absolute';
+          r.style.width = r.style.height = d + 'px';
+          r.style.left = (e.offsetX - d/2) + 'px';
+          r.style.top = (e.offsetY - d/2) + 'px';
           r.style.borderRadius = '50%';
           r.style.background = 'radial-gradient(circle, rgba(255,255,255,.30) 0%, rgba(255,255,255,0) 60%)';
-          r.style.transform = 'scale(0)'; r.style.opacity = '0.7'; r.style.pointerEvents = 'none';
+          r.style.transform = 'scale(0)';
+          r.style.opacity = '0.7';
+          r.style.pointerEvents = 'none';
           r.style.transition = 'transform .45s ease, opacity .6s ease';
           btn.appendChild(r);
-          requestAnimationFrame(() => { r.style.transform = 'scale(1)'; r.style.opacity = '0'; });
+          requestAnimationFrame(() => {
+            r.style.transform = 'scale(1)';
+            r.style.opacity = '0';
+          });
           setTimeout(() => r.remove(), 620);
         });
       });


### PR DESCRIPTION
## Summary
- rework the base admin UI styling tokens and gradients for improved presentation
- implement persistent light and dark theme variants with automatic detection and toggle script
- add a header theme toggle control and responsive refinements for navigation and content blocks

## Testing
- pytest *(fails: async tests require pytest-asyncio plugin in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d9754bbfd48333bde988ab89cfcf79