### PR TITLE
Extend admin UI fmt_local helper

### DIFF
--- a/backend/apps/admin_ui/services.py
+++ b/backend/apps/admin_ui/services.py
@@ -12,7 +12,13 @@ from sqlalchemy.exc import IntegrityError
 from backend.core.db import async_session
 from backend.domain.models import City, Recruiter, Slot, SlotStatus, Template, TestQuestion
 from backend.domain.template_stages import CITY_TEMPLATE_STAGES, STAGE_DEFAULTS
+
+# -----------------------------
+# ВСПОМОГАТЕЛЬНЫЕ КОНСТАНТЫ/ФУНКЦИИ
+# -----------------------------
+
 from backend.apps.admin_ui.utils import (
+    fmt_local,
     norm_status,
     paginate,
     recruiter_time_to_utc,
@@ -20,7 +26,7 @@ from backend.apps.admin_ui.utils import (
 )
 
 # -----------------------------
-# ВСПОМОГАТЕЛЬНЫЕ КОНСТАНТЫ/ФУНКЦИИ
+# DASHBOARD / СЧЁТЧИКИ
 # -----------------------------
 
 TEST_LABELS = {
@@ -29,34 +35,6 @@ TEST_LABELS = {
 }
 
 STAGE_KEYS: List[str] = [stage.key for stage in CITY_TEMPLATE_STAGES]
-
-# Локализация времени: безопасно конвертирует в нужный часовой пояс и форматирует
-from zoneinfo import ZoneInfo  # stdlib, Python 3.9+
-
-def fmt_local(
-    dt: Optional[datetime],
-    tz: str = "Europe/Moscow",
-    fmt: str = "%d.%m.%Y %H:%M",
-) -> str:
-    """
-    Преобразует datetime в локальную зону и форматирует строкой.
-    Если dt naive — считаем, что он в UTC.
-    Возвращает пустую строку, если dt отсутствует.
-    """
-    if not dt:
-        return ""
-    if dt.tzinfo is None:
-        dt = dt.replace(tzinfo=timezone.utc)
-    try:
-        return dt.astimezone(ZoneInfo(tz)).strftime(fmt)
-    except Exception:
-        # на случай некорректного tz — не падаем
-        return dt.astimezone(ZoneInfo("UTC")).strftime(fmt)
-
-
-# -----------------------------
-# DASHBOARD / СЧЁТЧИКИ
-# -----------------------------
 
 async def dashboard_counts() -> Dict[str, int]:
     async with async_session() as session:

--- a/backend/apps/admin_ui/utils.py
+++ b/backend/apps/admin_ui/utils.py
@@ -20,11 +20,11 @@ def safe_zone(tz_str: Optional[str]) -> ZoneInfo:
         return ZoneInfo(DEFAULT_TZ)
 
 
-def fmt_local(dt_utc: datetime, tz_str: str) -> str:
+def fmt_local(dt_utc: datetime, tz_str: Optional[str], fmt: str = "%d.%m %H:%M") -> str:
     if dt_utc.tzinfo is None:
         dt_utc = dt_utc.replace(tzinfo=timezone.utc)
     local = dt_utc.astimezone(safe_zone(tz_str))
-    return local.strftime("%d.%m %H:%M")
+    return local.strftime(fmt)
 
 
 def fmt_utc(dt_utc: datetime) -> str:

--- a/tests/test_admin_ui_utils.py
+++ b/tests/test_admin_ui_utils.py
@@ -1,0 +1,31 @@
+from datetime import datetime, timezone
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+_SPEC = importlib.util.spec_from_file_location(
+    "admin_ui_utils_for_tests",
+    Path(__file__).resolve().parents[1] / "backend" / "apps" / "admin_ui" / "utils.py",
+)
+_utils = importlib.util.module_from_spec(_SPEC)
+assert _SPEC.loader is not None
+_SPEC.loader.exec_module(_utils)  # type: ignore[attr-defined]
+fmt_local = _utils.fmt_local
+
+
+def test_fmt_local_default_format():
+    dt = datetime(2024, 1, 2, 3, 4, tzinfo=timezone.utc)
+    assert fmt_local(dt, "Europe/Moscow") == "02.01 06:04"
+
+
+def test_fmt_local_custom_format():
+    dt = datetime(2024, 1, 2, 3, 4, tzinfo=timezone.utc)
+    assert fmt_local(dt, "Europe/Moscow", fmt="%Y-%m-%d %H:%M") == "2024-01-02 06:04"
+
+
+@pytest.mark.parametrize("tz", ["", "Invalid/Zone"])
+def test_fmt_local_safe_zone_fallback(tz: str):
+    dt = datetime(2024, 1, 2, 3, 4, tzinfo=timezone.utc)
+    assert fmt_local(dt, tz) == "02.01 06:04"


### PR DESCRIPTION
## Summary
- add an optional format parameter to the shared `fmt_local` helper while reusing the existing timezone safeguards
- update admin UI services to use the shared formatter and drop the duplicate implementation
- cover the formatter with dedicated unit tests, including the new format parameter

## Testing
- pytest tests/test_admin_ui_utils.py tests/test_admin_ui_services.py

------
https://chatgpt.com/codex/tasks/task_e_68d97b8212108333baa80e1b7ecab499