### PR TITLE
feat: store survey responses and attach in recruiter flow

### DIFF
--- a/backend/core/db.py
+++ b/backend/core/db.py
@@ -48,7 +48,7 @@ async def init_models() -> None:
     from backend.domain.base import Base
 
     async with async_engine.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
+        await conn.run_sync(lambda sync_conn: Base.metadata.create_all(sync_conn, checkfirst=True))
         await _ensure_city_owner_column(conn)
         await _ensure_slot_purpose_column(conn)
 

--- a/backend/domain/candidates/__init__.py
+++ b/backend/domain/candidates/__init__.py
@@ -3,6 +3,7 @@
 from . import models  # noqa: F401  # ensure models are registered
 from .services import (  # noqa: F401
     create_or_update_user,
+    save_survey_response,
     save_test_result,
     get_user_by_telegram_id,
     get_all_active_users,
@@ -11,10 +12,12 @@ from .services import (  # noqa: F401
     get_active_auto_messages,
     create_notification,
     mark_notification_sent,
+    load_survey_summary,
 )
 
 __all__ = [
     "create_or_update_user",
+    "save_survey_response",
     "save_test_result",
     "get_user_by_telegram_id",
     "get_all_active_users",
@@ -23,4 +26,5 @@ __all__ = [
     "get_active_auto_messages",
     "create_notification",
     "mark_notification_sent",
+    "load_survey_summary",
 ]

--- a/backend/domain/candidates/models.py
+++ b/backend/domain/candidates/models.py
@@ -34,6 +34,9 @@ class User(Base):
     test_results: Mapped[List["TestResult"]] = relationship(
         back_populates="user", cascade="all, delete-orphan"
     )
+    survey_responses: Mapped[List["SurveyResponse"]] = relationship(
+        back_populates="user", cascade="all, delete-orphan"
+    )
 
     def __repr__(self) -> str:  # pragma: no cover - repr helper
         return f"<User {self.id} tg={self.telegram_id}>"
@@ -125,3 +128,24 @@ class Notification(Base):
 
     def __repr__(self) -> str:  # pragma: no cover - repr helper
         return f"<Notification {self.id} type={self.notification_type}>"
+
+
+class SurveyResponse(Base):
+    __tablename__ = "survey_responses"
+    __test__ = False  # prevent pytest from treating the model as a test case
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    user_id: Mapped[int] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"), nullable=False
+    )
+    answers_json: Mapped[str] = mapped_column(Text, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+    )
+
+    user: Mapped["User"] = relationship(back_populates="survey_responses")
+
+    def __repr__(self) -> str:  # pragma: no cover - repr helper
+        return f"<SurveyResponse {self.id} user={self.user_id}>"

--- a/tests/test_bot_survey.py
+++ b/tests/test_bot_survey.py
@@ -1,0 +1,111 @@
+import importlib
+import json
+import sys
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+@pytest.fixture()
+def bot_module(monkeypatch):
+    monkeypatch.setenv("BOT_TOKEN", "123:TEST")
+    import backend.core.settings as settings_module
+    settings_module.get_settings.cache_clear()
+    if "bot" in sys.modules:
+        bot_mod = importlib.reload(sys.modules["bot"])
+    else:
+        bot_mod = importlib.import_module("bot")
+    return bot_mod
+
+
+@pytest.mark.asyncio
+async def test_finalize_and_pick_slot_without_files(monkeypatch, bot_module):
+    bot = bot_module
+    user_id = 12345
+
+    fake_user = SimpleNamespace(id=42, telegram_id=user_id, fio="Имя", city="Москва")
+    monkeypatch.setattr(bot.candidate_services, "create_or_update_user", AsyncMock(return_value=fake_user))
+    save_mock = AsyncMock()
+    monkeypatch.setattr(bot.candidate_services, "save_survey_response", save_mock)
+    load_mock = AsyncMock()
+    monkeypatch.setattr(bot.candidate_services, "load_survey_summary", load_mock)
+    monkeypatch.setattr(bot.candidate_services, "get_user_by_telegram_id", AsyncMock(return_value=fake_user))
+
+    tpl_mock = AsyncMock(return_value="text")
+    monkeypatch.setattr(bot, "tpl", tpl_mock)
+    monkeypatch.setattr(bot, "_show_recruiter_menu", AsyncMock())
+    monkeypatch.setattr(bot.bot, "send_message", AsyncMock())
+    send_document_mock = AsyncMock()
+    monkeypatch.setattr(bot.bot, "send_document", send_document_mock)
+
+    monkeypatch.setattr("builtins.open", MagicMock(side_effect=AssertionError("file operations are not expected")))
+
+    bot.user_data[user_id] = {
+        "t1_sequence": [
+            {"id": "fio", "prompt": "ФИО"},
+            {"id": "city", "prompt": "Город"},
+        ],
+        "test1_answers": {"fio": "Имя", "city": "Москва"},
+        "fio": "Имя",
+        "city_name": "Москва",
+        "city_id": 1,
+        "candidate_tz": "Europe/Moscow",
+    }
+
+    await bot.finalize_test1(user_id)
+
+    assert save_mock.await_count == 1
+    save_args = save_mock.await_args
+    assert save_args.args[0] == fake_user.id
+    payload = save_args.args[1]
+    assert payload["meta"]["fio"] == "Имя"
+    assert bot.user_data[user_id]["candidate_db_id"] == fake_user.id
+
+    survey_payload = {
+        "meta": payload["meta"],
+        "questions": payload["questions"],
+        "summary_text": payload["summary_text"],
+    }
+    fake_response = SimpleNamespace(
+        answers_json=json.dumps(survey_payload, ensure_ascii=False),
+        created_at=datetime.now(timezone.utc),
+    )
+    load_mock.return_value = fake_response
+
+    slot_obj = SimpleNamespace(
+        id=7,
+        recruiter_id=9,
+        candidate_fio="Имя",
+        start_utc=datetime.now(timezone.utc),
+    )
+    monkeypatch.setattr(bot, "reserve_slot", AsyncMock(return_value=slot_obj))
+    recruiter = SimpleNamespace(tz="Europe/Moscow", tg_chat_id=555)
+    monkeypatch.setattr(bot, "get_recruiter", AsyncMock(return_value=recruiter))
+    monkeypatch.setattr(bot, "kb_approve", lambda slot_id: "kb")
+
+    message = SimpleNamespace(
+        edit_text=AsyncMock(),
+        edit_reply_markup=AsyncMock(),
+    )
+    callback = SimpleNamespace(
+        data="pick_slot:9:7",
+        from_user=SimpleNamespace(id=user_id),
+        message=message,
+        answer=AsyncMock(),
+    )
+
+    await bot.pick_slot(callback)
+
+    assert load_mock.await_count == 1
+    assert send_document_mock.await_count == 1
+    doc_call = send_document_mock.await_args
+    document = doc_call.kwargs["document"]
+    from aiogram.types import BufferedInputFile  # imported lazily for test clarity
+
+    assert isinstance(document, BufferedInputFile)
+    assert document.filename.endswith(".txt")
+    assert callback.answer.await_count >= 1
+
+    bot.user_data.pop(user_id, None)


### PR DESCRIPTION
## Summary
- add a SurveyResponse ORM model and register new survey persistence helpers
- persist test1 answers via the new services and build recruiter attachments from buffered content
- cover the flow with service and bot tests, exercising in-memory attachments

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d97b7774308333bf2e83e51222fc96