### PR TITLE
Add persistent state manager and reminder worker

### DIFF
--- a/backend/apps/bot/__init__.py
+++ b/backend/apps/bot/__init__.py
@@ -1,5 +1,13 @@
 """Bot application package exports."""
 
-from bot import bot, dp, main  # noqa: F401
+from importlib import import_module
+from typing import Any
 
 __all__ = ["bot", "dp", "main"]
+
+
+def __getattr__(name: str) -> Any:
+    if name in __all__:
+        module = import_module("bot")
+        return getattr(module, name)
+    raise AttributeError(name)

--- a/backend/apps/bot/state_manager.py
+++ b/backend/apps/bot/state_manager.py
@@ -1,0 +1,274 @@
+"""State manager and reminder scheduler helpers for the Telegram bot."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Awaitable, Callable, Dict, Iterable, List, Optional
+
+from aiogram import Bot
+from aiogram.fsm.storage.base import BaseStorage, StorageKey
+from aiogram.fsm.storage.memory import MemoryStorage
+
+try:  # pragma: no cover - optional dependency
+    from aiogram.fsm.storage.redis import DefaultKeyBuilder, RedisStorage
+except Exception:  # pragma: no cover - redis is optional in tests
+    RedisStorage = None  # type: ignore[assignment]
+    DefaultKeyBuilder = None  # type: ignore[assignment]
+
+from backend.core.settings import Settings
+
+
+@dataclass(slots=True)
+class ReminderMeta:
+    """Metadata describing a reminder event."""
+
+    slot_id: int
+    candidate_id: int
+    notify_at: datetime
+    kind: str
+    payload: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "slot_id": self.slot_id,
+            "candidate_id": self.candidate_id,
+            "notify_at": self.notify_at.astimezone(timezone.utc).isoformat(),
+            "kind": self.kind,
+            "payload": self.payload,
+        }
+
+    @classmethod
+    def from_dict(cls, raw: Dict[str, Any]) -> "ReminderMeta":
+        notify_at = raw.get("notify_at")
+        if isinstance(notify_at, str):
+            notify_at_dt = datetime.fromisoformat(notify_at)
+        elif isinstance(notify_at, datetime):
+            notify_at_dt = notify_at
+        else:  # pragma: no cover - defensive branch
+            raise ValueError("notify_at must be provided")
+        if notify_at_dt.tzinfo is None:
+            notify_at_dt = notify_at_dt.replace(tzinfo=timezone.utc)
+        return cls(
+            slot_id=int(raw["slot_id"]),
+            candidate_id=int(raw["candidate_id"]),
+            notify_at=notify_at_dt.astimezone(timezone.utc),
+            kind=str(raw["kind"]),
+            payload=dict(raw.get("payload") or {}),
+        )
+
+
+class StateManager:
+    """Encapsulates access to aiogram FSM storage and reminder metadata."""
+
+    REMINDER_DESTINY = "reminders"
+
+    def __init__(self, storage: BaseStorage):
+        self._storage = storage
+        self._bot_id: Optional[int] = None
+        self._lock = asyncio.Lock()
+
+    def set_bot_id(self, bot_id: int) -> None:
+        self._bot_id = bot_id
+
+    def require_ready(self) -> None:
+        if self._bot_id is None:
+            raise RuntimeError("StateManager is not initialised with bot_id yet")
+
+    def _user_key(self, user_id: int) -> StorageKey:
+        self.require_ready()
+        return StorageKey(bot_id=self._bot_id, chat_id=user_id, user_id=user_id)
+
+    def _reminder_key(self) -> StorageKey:
+        self.require_ready()
+        return StorageKey(
+            bot_id=self._bot_id,
+            chat_id=0,
+            user_id=0,
+            destiny=self.REMINDER_DESTINY,
+        )
+
+    async def load_state(self, user_id: int) -> Dict[str, Any]:
+        """Return per-user state stored in FSM storage."""
+        key = self._user_key(user_id)
+        data = await self._storage.get_data(key)
+        return dict(data)
+
+    async def save_state(self, user_id: int, data: Dict[str, Any]) -> None:
+        """Persist per-user state."""
+        key = self._user_key(user_id)
+        await self._storage.set_data(key, dict(data))
+
+    async def update_state(self, user_id: int, **changes: Any) -> Dict[str, Any]:
+        """Utility helper to update state atomically."""
+        async with self._lock:
+            state = await self.load_state(user_id)
+            state.update(changes)
+            await self.save_state(user_id, state)
+            return state
+
+    async def clear_state(self, user_id: int) -> None:
+        key = self._user_key(user_id)
+        await self._storage.set_data(key, {})
+
+    async def schedule_reminder(
+        self,
+        *,
+        slot_id: int,
+        candidate_id: int,
+        notify_at: datetime,
+        kind: str,
+        payload: Optional[Dict[str, Any]] = None,
+    ) -> ReminderMeta:
+        """Store reminder metadata in persistent storage."""
+        reminder = ReminderMeta(
+            slot_id=slot_id,
+            candidate_id=candidate_id,
+            notify_at=notify_at.astimezone(timezone.utc),
+            kind=kind,
+            payload=payload or {},
+        )
+        async with self._lock:
+            reminders = await self._load_reminders()
+            key = (slot_id, candidate_id, kind)
+            filtered = [
+                r for r in reminders if (r.slot_id, r.candidate_id, r.kind) != key
+            ]
+            filtered.append(reminder)
+            await self._save_reminders(filtered)
+        return reminder
+
+    async def cancel_reminder(
+        self,
+        *,
+        slot_id: int,
+        candidate_id: int,
+        kind: Optional[str] = None,
+    ) -> None:
+        """Remove reminder metadata for a slot/candidate."""
+        async with self._lock:
+            reminders = await self._load_reminders()
+            if kind is None:
+                filtered = [
+                    r
+                    for r in reminders
+                    if (r.slot_id, r.candidate_id) != (slot_id, candidate_id)
+                ]
+            else:
+                filtered = [
+                    r
+                    for r in reminders
+                    if (r.slot_id, r.candidate_id, r.kind)
+                    != (slot_id, candidate_id, kind)
+                ]
+            if len(filtered) != len(reminders):
+                await self._save_reminders(filtered)
+
+    async def pop_due_reminders(self, *, now: Optional[datetime] = None) -> List[ReminderMeta]:
+        """Retrieve and remove reminders that are due."""
+        current = (now or datetime.now(timezone.utc)).astimezone(timezone.utc)
+        async with self._lock:
+            reminders = await self._load_reminders()
+            due: List[ReminderMeta] = []
+            future: List[ReminderMeta] = []
+            for reminder in reminders:
+                if reminder.notify_at <= current:
+                    due.append(reminder)
+                else:
+                    future.append(reminder)
+            if len(future) != len(reminders):
+                await self._save_reminders(future)
+        return due
+
+    async def _load_reminders(self) -> List[ReminderMeta]:
+        key = self._reminder_key()
+        raw = await self._storage.get_data(key)
+        entries = raw.get("reminders", []) if isinstance(raw, dict) else []
+        return [ReminderMeta.from_dict(item) for item in entries]
+
+    async def _save_reminders(self, reminders: Iterable[ReminderMeta]) -> None:
+        key = self._reminder_key()
+        await self._storage.set_data(
+            key,
+            {"reminders": [item.to_dict() for item in reminders]},
+        )
+
+
+class ReminderWorker:
+    """Background worker that dispatches reminders when they become due."""
+
+    def __init__(
+        self,
+        state_manager: StateManager,
+        *,
+        poll_interval: float = 5.0,
+    ) -> None:
+        self._state_manager = state_manager
+        self._poll_interval = poll_interval
+        self._callbacks: Dict[str, Callable[[ReminderMeta], Awaitable[None]]] = {}
+        self._task: Optional[asyncio.Task[None]] = None
+        self._stop_event = asyncio.Event()
+
+    def register_handler(
+        self, kind: str, handler: Callable[[ReminderMeta], Awaitable[None]]
+    ) -> None:
+        self._callbacks[kind] = handler
+
+    async def start(self) -> None:
+        if self._task:
+            return
+        self._stop_event.clear()
+        self._task = asyncio.create_task(self._run())
+
+    async def stop(self) -> None:
+        if not self._task:
+            return
+        self._stop_event.set()
+        await self._task
+        self._task = None
+
+    async def _run(self) -> None:
+        try:
+            while not self._stop_event.is_set():
+                due = await self._state_manager.pop_due_reminders()
+                for reminder in due:
+                    handler = self._callbacks.get(reminder.kind)
+                    if not handler:
+                        continue
+                    try:
+                        await handler(reminder)
+                    except Exception:  # pragma: no cover - logging happens in caller
+                        # Handler is responsible for logging, but we must not crash the loop.
+                        pass
+                await asyncio.wait(
+                    [self._stop_event.wait()],
+                    timeout=self._poll_interval,
+                )
+        finally:
+            self._task = None
+
+
+def create_storage(settings: Settings) -> BaseStorage:
+    """Factory creating FSM storage based on settings."""
+    backend = (settings.state_storage_backend or "").lower()
+    if backend == "redis":
+        if RedisStorage is None or DefaultKeyBuilder is None:  # pragma: no cover
+            raise RuntimeError("Redis storage backend requires aiogram redis extras")
+        if not settings.state_storage_dsn:
+            raise ValueError("REDIS_DSN must be provided for redis backend")
+        return RedisStorage.from_url(
+            settings.state_storage_dsn,
+            key_builder=DefaultKeyBuilder(with_destiny=True),
+        )
+    # Default: in-memory storage suitable for tests and development.
+    return MemoryStorage()
+
+
+async def ensure_state_manager_ready(bot: Bot, state_manager: StateManager) -> None:
+    """Populate bot id in the state manager."""
+    if getattr(bot, "id", None) is None:
+        me = await bot.get_me()
+        state_manager.set_bot_id(me.id)
+    else:
+        state_manager.set_bot_id(bot.id)

--- a/backend/core/settings.py
+++ b/backend/core/settings.py
@@ -18,6 +18,8 @@ class Settings:
     bot_token: str
     admin_chat_id: int
     timezone: str
+    state_storage_backend: str
+    state_storage_dsn: str | None
 
 
 load_env()
@@ -76,6 +78,15 @@ def get_settings() -> Settings:
     admin_chat_id = int(os.getenv("ADMIN_CHAT_ID", "0") or 0)
     timezone = os.getenv("TZ", "Europe/Moscow")
 
+    redis_dsn = os.getenv("REDIS_DSN")
+    state_backend = os.getenv("STATE_STORAGE_BACKEND")
+    if redis_dsn and not state_backend:
+        state_backend = "redis"
+    if not state_backend:
+        # Memory storage is a safe default for local development when no
+        # external state backend is configured.
+        state_backend = "memory"
+
     return Settings(
         data_dir=data_dir,
         database_url_async=async_url,
@@ -84,4 +95,6 @@ def get_settings() -> Settings:
         bot_token=bot_token,
         admin_chat_id=admin_chat_id,
         timezone=timezone,
+        state_storage_backend=state_backend,
+        state_storage_dsn=redis_dsn,
     )

--- a/tests/test_state_manager.py
+++ b/tests/test_state_manager.py
@@ -1,0 +1,86 @@
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from aiogram.fsm.storage.memory import MemoryStorage
+
+from backend.apps.bot.state_manager import ReminderMeta, StateManager
+
+
+@pytest.mark.asyncio
+async def test_load_save_and_update_state():
+    storage = MemoryStorage()
+    manager = StateManager(storage)
+    manager.set_bot_id(1)
+
+    assert await manager.load_state(10) == {}
+
+    await manager.save_state(10, {"foo": "bar"})
+    assert await manager.load_state(10) == {"foo": "bar"}
+
+    updated = await manager.update_state(10, foo="baz", extra=1)
+    assert updated["foo"] == "baz"
+    assert updated["extra"] == 1
+
+    await manager.clear_state(10)
+    assert await manager.load_state(10) == {}
+
+
+@pytest.mark.asyncio
+async def test_schedule_and_cancel_reminders():
+    storage = MemoryStorage()
+    manager = StateManager(storage)
+    manager.set_bot_id(2)
+
+    base = datetime.now(timezone.utc)
+    await manager.schedule_reminder(
+        slot_id=1,
+        candidate_id=2,
+        notify_at=base + timedelta(seconds=1),
+        kind="demo",
+    )
+
+    # Not yet due
+    assert await manager.pop_due_reminders(now=base) == []
+
+    # Due reminders are returned once
+    due = await manager.pop_due_reminders(now=base + timedelta(seconds=2))
+    assert len(due) == 1
+    assert isinstance(due[0], ReminderMeta)
+    assert due[0].slot_id == 1
+
+    # Subsequent calls empty
+    assert await manager.pop_due_reminders(now=base + timedelta(seconds=3)) == []
+
+    await manager.schedule_reminder(
+        slot_id=3,
+        candidate_id=4,
+        notify_at=base + timedelta(seconds=1),
+        kind="demo",
+    )
+    await manager.cancel_reminder(slot_id=3, candidate_id=4, kind="demo")
+    assert await manager.pop_due_reminders(now=base + timedelta(seconds=3)) == []
+
+
+@pytest.mark.asyncio
+async def test_state_persists_with_shared_storage():
+    storage = MemoryStorage()
+
+    manager1 = StateManager(storage)
+    manager1.set_bot_id(5)
+    await manager1.save_state(42, {"foo": "bar"})
+    future = datetime.now(timezone.utc) + timedelta(seconds=1)
+    await manager1.schedule_reminder(
+        slot_id=9,
+        candidate_id=42,
+        notify_at=future,
+        kind="demo",
+    )
+
+    # "Restart" with a new manager using the same storage instance
+    manager2 = StateManager(storage)
+    manager2.set_bot_id(5)
+
+    assert await manager2.load_state(42) == {"foo": "bar"}
+    due = await manager2.pop_due_reminders(now=future + timedelta(seconds=1))
+    assert len(due) == 1
+    assert due[0].candidate_id == 42


### PR DESCRIPTION
## Summary
- add configurable state storage options with Redis support and development fallback
- introduce an FSM-based state manager and reminder worker to persist user state and reminder metadata
- refactor the bot to use the new state manager plus schedule reminders through the worker and add unit tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d97b7826e08333b7fb502d5b638b98