### PR TITLE
Fix CLI bot import after package refactor

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import asyncio
 import logging
 
-from backend.apps.bot.app import main
+from backend.apps.bot import main
 
 
 def run() -> None:


### PR DESCRIPTION
## Summary
- update the CLI entry point to import the bot's main routine from the package export

## Testing
- pytest *(fails: missing optional dependencies such as sqlalchemy and aiogram)*

------
https://chatgpt.com/codex/tasks/task_e_68d980cf6f2483338fd78c84c9d6d37b