### PR TITLE
Add managed migrations for schema and seed data

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,19 @@ python3 -m pytest
 If you prefer to call `pytest` directly, ensure that your shell `PATH` includes
 `~/.local/bin` (or the equivalent directory where your Python environment
 installs console scripts).
+
+## Database migrations and seed data
+
+The database schema is managed through Python migration scripts located under
+`backend/migrations`. Both the web applications and the bot call
+`backend.core.db.init_models()` during startup, which upgrades the database to
+the latest revision and applies the default seed data.
+
+For brand new environments or CI setups you can run the same logic manually:
+
+```bash
+python -c "from backend.migrations import upgrade_to_head; upgrade_to_head()"
+```
+
+The seeding step is idempotent and can be executed multiple times without
+creating duplicate cities, recruiters or test questions.

--- a/backend/core/db.py
+++ b/backend/core/db.py
@@ -1,11 +1,10 @@
 from __future__ import annotations
-
 from contextlib import asynccontextmanager, contextmanager
 from typing import AsyncIterator, Iterator
 
-import json
+import asyncio
 
-from sqlalchemy import create_engine, text, select, func
+from sqlalchemy import create_engine
 from sqlalchemy.ext.asyncio import (
     AsyncEngine,
     AsyncSession,
@@ -15,6 +14,7 @@ from sqlalchemy.ext.asyncio import (
 from sqlalchemy.orm import Session, sessionmaker
 
 from backend.core.settings import get_settings
+from backend.migrations import upgrade_to_head
 
 _settings = get_settings()
 
@@ -42,103 +42,9 @@ _sync_session_factory = sessionmaker(
 
 
 async def init_models() -> None:
-    """Ensure all ORM tables exist."""
-    from backend.domain import models  # noqa: F401  # импортирует модели для metadata
-    from backend.domain.candidates import models as candidates_models  # noqa: F401
-    from backend.domain.base import Base
+    """Initialise the database by applying all migrations."""
 
-    async with async_engine.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
-        await _ensure_city_owner_column(conn)
-        await _ensure_slot_purpose_column(conn)
-
-    await _seed_defaults()
-
-
-async def _ensure_city_owner_column(conn) -> None:
-    """Добавляет колонку responsible_recruiter_id в cities при необходимости."""
-    result = await conn.execute(text("PRAGMA table_info('cities')"))
-    columns = {row[1] for row in result}
-    if "responsible_recruiter_id" not in columns:
-        await conn.execute(
-            text(
-                "ALTER TABLE cities ADD COLUMN responsible_recruiter_id INTEGER "
-                "REFERENCES recruiters(id) ON DELETE SET NULL"
-            )
-        )
-
-
-async def _ensure_slot_purpose_column(conn) -> None:
-    """Гарантирует наличие вспомогательных столбцов в таблице slots."""
-    result = await conn.execute(text("PRAGMA table_info('slots')"))
-    columns = {row[1] for row in result}
-    if "purpose" not in columns:
-        await conn.execute(
-            text(
-                "ALTER TABLE slots ADD COLUMN purpose VARCHAR(32) NOT NULL DEFAULT 'interview'"
-            )
-        )
-    if "candidate_city_id" not in columns:
-        await conn.execute(
-            text(
-                "ALTER TABLE slots ADD COLUMN candidate_city_id INTEGER REFERENCES cities(id) ON DELETE SET NULL"
-            )
-        )
-
-
-DEFAULT_CITIES = [
-    {"name": "Москва", "tz": "Europe/Moscow"},
-    {"name": "Санкт-Петербург", "tz": "Europe/Moscow"},
-    {"name": "Новосибирск", "tz": "Asia/Novosibirsk"},
-    {"name": "Екатеринбург", "tz": "Asia/Yekaterinburg"},
-]
-
-DEFAULT_RECRUITERS = [
-    {
-        "name": "Михаил Шеншин",
-        "tz": "Europe/Moscow",
-        "telemost_url": "https://telemost.yandex.ru/j/SMART_ONBOARDING",
-        "active": True,
-    },
-    {
-        "name": "Юлия Начауридзе",
-        "tz": "Europe/Moscow",
-        "telemost_url": "https://telemost.yandex.ru/j/SMART_RECRUIT",
-        "active": True,
-    },
-]
-
-
-async def _seed_defaults() -> None:
-    from backend.domain.models import City, Recruiter, TestQuestion
-    from backend.domain.default_questions import DEFAULT_TEST_QUESTIONS
-
-    async with async_session() as session:
-        for city_data in DEFAULT_CITIES:
-            exists = await session.scalar(select(City).where(City.name == city_data["name"]))
-            if not exists:
-                session.add(City(**city_data))
-
-        for rec_data in DEFAULT_RECRUITERS:
-            exists = await session.scalar(select(Recruiter).where(Recruiter.name == rec_data["name"]))
-            if not exists:
-                session.add(Recruiter(**rec_data))
-
-        existing_questions = await session.scalar(select(func.count()).select_from(TestQuestion))
-        if not existing_questions:
-            for test_id, questions in DEFAULT_TEST_QUESTIONS.items():
-                for idx, question in enumerate(questions, start=1):
-                    title = question.get("prompt") or question.get("text") or f"Вопрос {idx}"
-                    session.add(
-                        TestQuestion(
-                            test_id=test_id,
-                            question_index=idx,
-                            title=title,
-                            payload=json.dumps(question, ensure_ascii=False),
-                        )
-                    )
-
-        await session.commit()
+    await asyncio.to_thread(upgrade_to_head, sync_engine)
 
 
 def new_async_session() -> AsyncSession:

--- a/backend/migrations/__init__.py
+++ b/backend/migrations/__init__.py
@@ -1,0 +1,5 @@
+"""Lightweight migration runner for the project."""
+
+from .runner import upgrade_to_head
+
+__all__ = ["upgrade_to_head"]

--- a/backend/migrations/runner.py
+++ b/backend/migrations/runner.py
@@ -1,0 +1,156 @@
+"""Minimal migration runner inspired by Alembic.
+
+This module discovers migration modules located inside
+``backend.migrations.versions`` and applies them sequentially while tracking
+state in the ``alembic_version`` table. Each migration module should expose
+``revision`` and ``down_revision`` identifiers along with ``upgrade`` and
+``downgrade`` callables that accept a synchronous SQLAlchemy connection.
+"""
+
+from __future__ import annotations
+
+import importlib
+import pkgutil
+from dataclasses import dataclass
+from pathlib import Path
+from types import ModuleType
+from typing import Iterable, List, Optional, Sequence
+
+from sqlalchemy import create_engine, text
+from sqlalchemy.engine import Connection, Engine
+
+from backend.core.settings import get_settings
+
+MIGRATIONS_PACKAGE = "backend.migrations.versions"
+VERSION_TABLE = "alembic_version"
+VERSION_COLUMN = "version_num"
+
+
+@dataclass(frozen=True)
+class MigrationModule:
+    """Container describing a single migration module."""
+
+    revision: str
+    down_revision: Optional[str]
+    module: ModuleType
+
+
+def _discover_migrations() -> List[MigrationModule]:
+    package = importlib.import_module(MIGRATIONS_PACKAGE)
+    package_path = Path(package.__file__).resolve().parent
+    modules: List[MigrationModule] = []
+
+    for module_info in pkgutil.iter_modules([str(package_path)]):
+        if module_info.ispkg or module_info.name.startswith("_"):
+            continue
+        module = importlib.import_module(f"{MIGRATIONS_PACKAGE}.{module_info.name}")
+        revision = getattr(module, "revision", None)
+        if revision is None:
+            raise RuntimeError(f"Migration {module_info.name} is missing 'revision'")
+        down_revision = getattr(module, "down_revision", None)
+        modules.append(MigrationModule(revision=revision, down_revision=down_revision, module=module))
+
+    modules.sort(key=lambda item: item.revision)
+
+    # Basic sanity check ensuring the chain is linear.
+    previous_revision: Optional[str] = None
+    for migration in modules:
+        if migration.down_revision not in {previous_revision, None}:
+            raise RuntimeError(
+                "Migrations are out of order: "
+                f"{migration.revision} declares down_revision={migration.down_revision}, "
+                f"expected {previous_revision!r}."
+            )
+        previous_revision = migration.revision
+
+    return modules
+
+
+def _ensure_version_storage(conn: Connection) -> None:
+    conn.execute(
+        text(
+            f"CREATE TABLE IF NOT EXISTS {VERSION_TABLE} "
+            f"({VERSION_COLUMN} VARCHAR(64) PRIMARY KEY)"
+        )
+    )
+
+
+def _get_current_revision(conn: Connection) -> Optional[str]:
+    result = conn.execute(text(f"SELECT {VERSION_COLUMN} FROM {VERSION_TABLE} LIMIT 1"))
+    row = result.first()
+    return row[0] if row else None
+
+
+def _set_current_revision(conn: Connection, revision: Optional[str]) -> None:
+    conn.execute(text(f"DELETE FROM {VERSION_TABLE}"))
+    if revision is not None:
+        conn.execute(
+            text(f"INSERT INTO {VERSION_TABLE} ({VERSION_COLUMN}) VALUES (:revision)"),
+            {"revision": revision},
+        )
+
+
+def _slice_pending_migrations(
+    migrations: Sequence[MigrationModule],
+    current_revision: Optional[str],
+    target_revision: Optional[str],
+) -> Iterable[MigrationModule]:
+    if not migrations:
+        return []
+
+    if target_revision is None:
+        target_index = len(migrations) - 1
+    else:
+        try:
+            target_index = next(i for i, item in enumerate(migrations) if item.revision == target_revision)
+        except StopIteration as exc:  # pragma: no cover - defensive branch
+            raise RuntimeError(f"Unknown migration revision: {target_revision}") from exc
+
+    if current_revision is None:
+        start_index = -1
+    else:
+        try:
+            start_index = next(i for i, item in enumerate(migrations) if item.revision == current_revision)
+        except StopIteration as exc:
+            raise RuntimeError(
+                f"Database is at unknown migration revision {current_revision!r}."
+            ) from exc
+
+    if target_index <= start_index:
+        return []
+
+    return migrations[start_index + 1 : target_index + 1]
+
+
+def upgrade_to_head(engine_or_url: Engine | str | None = None) -> None:
+    """Upgrade the database to the latest available migration."""
+
+    migrations = _discover_migrations()
+    if not migrations:
+        return
+
+    if engine_or_url is None:
+        settings = get_settings()
+        engine = create_engine(settings.database_url_sync, future=True)
+        should_dispose = True
+    elif isinstance(engine_or_url, Engine):
+        engine = engine_or_url
+        should_dispose = False
+    else:
+        engine = create_engine(engine_or_url, future=True)
+        should_dispose = True
+
+    try:
+        with engine.begin() as conn:
+            _ensure_version_storage(conn)
+            current = _get_current_revision(conn)
+            target = migrations[-1].revision
+            for migration in _slice_pending_migrations(migrations, current, target):
+                upgrade = getattr(migration.module, "upgrade", None)
+                if upgrade is None:
+                    raise RuntimeError(f"Migration {migration.revision} is missing upgrade()")
+                upgrade(conn)
+                _set_current_revision(conn, migration.revision)
+    finally:
+        if should_dispose:
+            engine.dispose()

--- a/backend/migrations/versions/0001_initial_schema.py
+++ b/backend/migrations/versions/0001_initial_schema.py
@@ -1,0 +1,171 @@
+"""Create core database tables."""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+
+revision = "0001_initial_schema"
+down_revision = None
+
+
+def _define_tables(metadata: sa.MetaData) -> None:
+    sa.Table(
+        "recruiters",
+        metadata,
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("name", sa.String(100), nullable=False),
+        sa.Column("tg_chat_id", sa.BigInteger, unique=True, nullable=True),
+        sa.Column("tz", sa.String(64), nullable=False, server_default=sa.text("'Europe/Moscow'")),
+        sa.Column("telemost_url", sa.String(255), nullable=True),
+        sa.Column("active", sa.Boolean, nullable=False, server_default=sa.true()),
+    )
+
+    sa.Table(
+        "cities",
+        metadata,
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("name", sa.String(120), nullable=False),
+        sa.Column("tz", sa.String(64), nullable=False, server_default=sa.text("'Europe/Moscow'")),
+        sa.Column("active", sa.Boolean, nullable=False, server_default=sa.true()),
+        sa.Column("responsible_recruiter_id", sa.Integer, nullable=True),
+        sa.ForeignKeyConstraint(
+            ["responsible_recruiter_id"],
+            ["recruiters.id"],
+            name="fk_cities_responsible_recruiter_id",
+            ondelete="SET NULL",
+        ),
+        sa.UniqueConstraint("name", name="uq_city_name"),
+    )
+
+    sa.Table(
+        "templates",
+        metadata,
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("city_id", sa.Integer, nullable=True),
+        sa.Column("key", sa.String(50), nullable=False),
+        sa.Column("content", sa.Text, nullable=False),
+        sa.ForeignKeyConstraint(["city_id"], ["cities.id"], name="fk_templates_city_id", ondelete="CASCADE"),
+        sa.UniqueConstraint("city_id", "key", name="uq_city_key"),
+    )
+
+    sa.Table(
+        "slots",
+        metadata,
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("recruiter_id", sa.Integer, nullable=False),
+        sa.Column("city_id", sa.Integer, nullable=True),
+        sa.Column("candidate_city_id", sa.Integer, nullable=True),
+        sa.Column("purpose", sa.String(32), nullable=False, server_default=sa.text("'interview'")),
+        sa.Column("start_utc", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("duration_min", sa.Integer, nullable=False, server_default=sa.text("60")),
+        sa.Column("status", sa.String(20), nullable=False, server_default=sa.text("'free'")),
+        sa.Column("candidate_tg_id", sa.BigInteger, nullable=True),
+        sa.Column("candidate_fio", sa.String(160), nullable=True),
+        sa.Column("candidate_tz", sa.String(64), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["recruiter_id"], ["recruiters.id"], name="fk_slots_recruiter_id", ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["city_id"], ["cities.id"], name="fk_slots_city_id", ondelete="SET NULL"),
+        sa.ForeignKeyConstraint(
+            ["candidate_city_id"],
+            ["cities.id"],
+            name="fk_slots_candidate_city_id",
+            ondelete="SET NULL",
+        ),
+    )
+
+    sa.Table(
+        "test_questions",
+        metadata,
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("test_id", sa.String(50), nullable=False),
+        sa.Column("question_index", sa.Integer, nullable=False),
+        sa.Column("title", sa.String(255), nullable=False),
+        sa.Column("payload", sa.Text, nullable=False),
+        sa.Column("is_active", sa.Boolean, nullable=False, server_default=sa.true()),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.UniqueConstraint("test_id", "question_index", name="uq_test_question_index"),
+    )
+
+    sa.Table(
+        "users",
+        metadata,
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("telegram_id", sa.BigInteger, nullable=False, unique=True),
+        sa.Column("fio", sa.String(160), nullable=False),
+        sa.Column("city", sa.String(120), nullable=True),
+        sa.Column("is_active", sa.Boolean, nullable=False, server_default=sa.true()),
+        sa.Column("last_activity", sa.DateTime(timezone=True), nullable=False),
+    )
+    sa.Index("ix_users_telegram_id", metadata.tables["users"].c.telegram_id)
+
+    sa.Table(
+        "test_results",
+        metadata,
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("user_id", sa.Integer, nullable=False),
+        sa.Column("raw_score", sa.Integer, nullable=False),
+        sa.Column("final_score", sa.Float, nullable=False),
+        sa.Column("rating", sa.String(50), nullable=False),
+        sa.Column("total_time", sa.Integer, nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], name="fk_test_results_user_id", ondelete="CASCADE"),
+    )
+
+    sa.Table(
+        "question_answers",
+        metadata,
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("test_result_id", sa.Integer, nullable=False),
+        sa.Column("question_index", sa.Integer, nullable=False),
+        sa.Column("question_text", sa.Text, nullable=False),
+        sa.Column("correct_answer", sa.Text, nullable=True),
+        sa.Column("user_answer", sa.Text, nullable=True),
+        sa.Column("attempts_count", sa.Integer, nullable=False, server_default=sa.text("0")),
+        sa.Column("time_spent", sa.Integer, nullable=False, server_default=sa.text("0")),
+        sa.Column("is_correct", sa.Boolean, nullable=False, server_default=sa.false()),
+        sa.Column("overtime", sa.Boolean, nullable=False, server_default=sa.false()),
+        sa.ForeignKeyConstraint(
+            ["test_result_id"],
+            ["test_results.id"],
+            name="fk_question_answers_test_result_id",
+            ondelete="CASCADE",
+        ),
+        sa.UniqueConstraint("test_result_id", "question_index", name="uq_test_result_question"),
+    )
+
+    sa.Table(
+        "auto_messages",
+        metadata,
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("message_text", sa.Text, nullable=False),
+        sa.Column("send_time", sa.String(64), nullable=False),
+        sa.Column("target_chat_id", sa.BigInteger, nullable=True),
+        sa.Column("is_active", sa.Boolean, nullable=False, server_default=sa.true()),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+    )
+
+    sa.Table(
+        "notifications",
+        metadata,
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("admin_chat_id", sa.BigInteger, nullable=False),
+        sa.Column("notification_type", sa.String(50), nullable=False),
+        sa.Column("message_text", sa.Text, nullable=False),
+        sa.Column("is_sent", sa.Boolean, nullable=False, server_default=sa.false()),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("sent_at", sa.DateTime(timezone=True), nullable=True),
+    )
+
+
+def upgrade(conn):
+    metadata = sa.MetaData()
+    _define_tables(metadata)
+    metadata.create_all(conn)
+
+
+def downgrade(conn):  # pragma: no cover - provided for completeness
+    metadata = sa.MetaData()
+    _define_tables(metadata)
+    metadata.drop_all(conn)

--- a/backend/migrations/versions/0002_seed_defaults.py
+++ b/backend/migrations/versions/0002_seed_defaults.py
@@ -1,0 +1,107 @@
+"""Seed default cities, recruiters and test questions."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, Iterable
+
+import sqlalchemy as sa
+
+from backend.domain.default_questions import DEFAULT_TEST_QUESTIONS
+
+revision = "0002_seed_defaults"
+down_revision = "0001_initial_schema"
+
+DEFAULT_CITIES = [
+    {"name": "Москва", "tz": "Europe/Moscow"},
+    {"name": "Санкт-Петербург", "tz": "Europe/Moscow"},
+    {"name": "Новосибирск", "tz": "Asia/Novosibirsk"},
+    {"name": "Екатеринбург", "tz": "Asia/Yekaterinburg"},
+]
+
+DEFAULT_RECRUITERS = [
+    {
+        "name": "Михаил Шеншин",
+        "tz": "Europe/Moscow",
+        "telemost_url": "https://telemost.yandex.ru/j/SMART_ONBOARDING",
+        "active": True,
+    },
+    {
+        "name": "Юлия Начауридзе",
+        "tz": "Europe/Moscow",
+        "telemost_url": "https://telemost.yandex.ru/j/SMART_RECRUIT",
+        "active": True,
+    },
+]
+
+
+def _table(name: str, *columns: sa.Column) -> sa.Table:
+    metadata = sa.MetaData()
+    return sa.Table(name, metadata, *columns)
+
+
+def _ensure_entries(conn: sa.Connection, table: sa.Table, *, unique_field: str, rows: Iterable[Dict[str, Any]]) -> None:
+    for row in rows:
+        exists = conn.execute(
+            sa.select(sa.literal(1)).select_from(table).where(table.c[unique_field] == row[unique_field])
+        ).scalar()
+        if exists:
+            continue
+        conn.execute(sa.insert(table).values(**row))
+
+
+def upgrade(conn):
+    cities = _table(
+        "cities",
+        sa.Column("id", sa.Integer),
+        sa.Column("name", sa.String),
+        sa.Column("tz", sa.String),
+        sa.Column("active", sa.Boolean),
+    )
+    recruiters = _table(
+        "recruiters",
+        sa.Column("id", sa.Integer),
+        sa.Column("name", sa.String),
+        sa.Column("tz", sa.String),
+        sa.Column("telemost_url", sa.String),
+        sa.Column("active", sa.Boolean),
+    )
+    test_questions = _table(
+        "test_questions",
+        sa.Column("id", sa.Integer),
+        sa.Column("test_id", sa.String),
+        sa.Column("question_index", sa.Integer),
+        sa.Column("title", sa.String),
+        sa.Column("payload", sa.Text),
+        sa.Column("is_active", sa.Boolean),
+    )
+
+    _ensure_entries(conn, cities, unique_field="name", rows=DEFAULT_CITIES)
+    _ensure_entries(conn, recruiters, unique_field="name", rows=DEFAULT_RECRUITERS)
+
+    existing_questions = conn.execute(sa.select(sa.func.count()).select_from(test_questions)).scalar()
+    if existing_questions:
+        return
+
+    for test_id, questions in DEFAULT_TEST_QUESTIONS.items():
+        for idx, question in enumerate(questions, start=1):
+            title = question.get("prompt") or question.get("text") or f"Вопрос {idx}"
+            conn.execute(
+                sa.insert(test_questions).values(
+                    test_id=test_id,
+                    question_index=idx,
+                    title=title,
+                    payload=json.dumps(question, ensure_ascii=False),
+                    is_active=True,
+                )
+            )
+
+
+def downgrade(conn):  # pragma: no cover - provided for completeness
+    test_questions = _table(
+        "test_questions",
+        sa.Column("test_id", sa.String),
+    )
+    conn.execute(
+        sa.delete(test_questions).where(test_questions.c.test_id.in_(list(DEFAULT_TEST_QUESTIONS.keys())))
+    )

--- a/backend/migrations/versions/__init__.py
+++ b/backend/migrations/versions/__init__.py
@@ -1,0 +1,1 @@
+"""Database schema migrations."""


### PR DESCRIPTION
## Summary
- introduce a lightweight migration runner and versioned scripts under `backend/migrations`
- capture the existing ORM schema in an initial migration and move the default seed data into a managed revision
- simplify `init_models` to invoke the migration runner and document the workflow for new environments

## Testing
- python -m pytest *(fails: missing optional dependencies such as sqlalchemy/aiogram in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d983b082088333a24d74d93919bc36