### PR TITLE
Refactor bot context management

### DIFF
--- a/backend/apps/bot/__init__.py
+++ b/backend/apps/bot/__init__.py
@@ -1,9 +1,10 @@
 """Bot application package exports."""
 
-from .app import create_application, create_bot, create_dispatcher, main
+from .app import BotContext, create_application, create_bot, create_dispatcher, main
 from .services import StateManager
 
 __all__ = [
+    "BotContext",
     "create_application",
     "create_bot",
     "create_dispatcher",

--- a/backend/apps/bot/handlers/__init__.py
+++ b/backend/apps/bot/handlers/__init__.py
@@ -2,18 +2,51 @@
 
 from __future__ import annotations
 
-from aiogram import Dispatcher
+from typing import Any
 
+from aiogram import Dispatcher
+from aiogram import Router
+from aiogram.types import TelegramObject
+from aiogram.dispatcher.middlewares.base import BaseMiddleware
+
+from ..services import BotContext
 from . import attendance, common, recruiter, slots, test1, test2
 
 __all__ = ["register_routers"]
 
 
-def register_routers(dp: Dispatcher) -> None:
+class ContextMiddleware(BaseMiddleware):
+    """Inject the bot context into handler data."""
+
+    def __init__(self, context: BotContext) -> None:
+        super().__init__()
+        self._context = context
+
+    async def __call__(
+        self,
+        handler,
+        event: TelegramObject,
+        data: dict,
+    ) -> Any:
+        data.setdefault("context", self._context)
+        return await handler(event, data)
+
+
+def _register_with_context(dp: Dispatcher, router: Router, context: BotContext) -> None:
+    router.message.middleware.register(ContextMiddleware(context))
+    router.callback_query.middleware.register(ContextMiddleware(context))
+    dp.include_router(router)
+
+
+def register_routers(dp: Dispatcher, context: BotContext) -> None:
     """Include all bot routers into the dispatcher."""
-    dp.include_router(common.router)
-    dp.include_router(test1.router)
-    dp.include_router(test2.router)
-    dp.include_router(slots.router)
-    dp.include_router(recruiter.router)
-    dp.include_router(attendance.router)
+
+    for router in (
+        common.router,
+        test1.router,
+        test2.router,
+        slots.router,
+        recruiter.router,
+        attendance.router,
+    ):
+        _register_with_context(dp, router, context)

--- a/backend/apps/bot/handlers/attendance.py
+++ b/backend/apps/bot/handlers/attendance.py
@@ -6,15 +6,16 @@ from aiogram import F, Router
 from aiogram.types import CallbackQuery
 
 from .. import services
+from ..services import BotContext
 
 router = Router()
 
 
 @router.callback_query(F.data.startswith("att_yes:"))
-async def attendance_yes(callback: CallbackQuery) -> None:
-    await services.handle_attendance_yes(callback)
+async def attendance_yes(callback: CallbackQuery, context: BotContext) -> None:
+    await services.handle_attendance_yes(context, callback)
 
 
 @router.callback_query(F.data.startswith("att_no:"))
-async def attendance_no(callback: CallbackQuery) -> None:
-    await services.handle_attendance_no(callback)
+async def attendance_no(callback: CallbackQuery, context: BotContext) -> None:
+    await services.handle_attendance_no(context, callback)

--- a/backend/apps/bot/handlers/common.py
+++ b/backend/apps/bot/handlers/common.py
@@ -7,32 +7,33 @@ from aiogram.filters import Command
 from aiogram.types import CallbackQuery, Message
 
 from .. import services
+from ..services import BotContext
 
 router = Router()
 
 
 @router.message(Command("start"))
-async def cmd_start(message: Message) -> None:
-    await services.begin_interview(message.from_user.id)
+async def cmd_start(message: Message, context: BotContext) -> None:
+    await services.begin_interview(context, message.from_user.id)
 
 
 @router.message(Command(commands=["intro", "test2"]))
-async def cmd_intro(message: Message) -> None:
-    await services.start_introday_flow(message)
+async def cmd_intro(message: Message, context: BotContext) -> None:
+    await services.start_introday_flow(context, message)
 
 
 @router.callback_query(F.data == "home:start")
-async def cb_home_start(callback: CallbackQuery) -> None:
-    await services.handle_home_start(callback)
+async def cb_home_start(callback: CallbackQuery, context: BotContext) -> None:
+    await services.handle_home_start(context, callback)
 
 
 @router.message()
-async def free_text(message: Message) -> None:
-    state = services.get_state_manager().get(message.from_user.id)
+async def free_text(message: Message, context: BotContext) -> None:
+    state = context.state_manager.get(message.from_user.id)
     if not state:
-        await services.send_welcome(message.from_user.id)
+        await services.send_welcome(context, message.from_user.id)
         return
     if state.get("flow") == "interview":
         idx = state.get("t1_idx")
         if isinstance(idx, int):
-            await services.handle_test1_answer(message)
+            await services.handle_test1_answer(context, message)

--- a/backend/apps/bot/handlers/recruiter.py
+++ b/backend/apps/bot/handlers/recruiter.py
@@ -6,15 +6,16 @@ from aiogram import F, Router
 from aiogram.types import CallbackQuery
 
 from .. import services
+from ..services import BotContext
 
 router = Router()
 
 
 @router.callback_query(F.data.startswith("approve:"))
-async def approve(callback: CallbackQuery) -> None:
-    await services.handle_approve_slot(callback)
+async def approve(callback: CallbackQuery, context: BotContext) -> None:
+    await services.handle_approve_slot(context, callback)
 
 
 @router.callback_query(F.data.startswith("reject:"))
-async def reject(callback: CallbackQuery) -> None:
-    await services.handle_reject_slot(callback)
+async def reject(callback: CallbackQuery, context: BotContext) -> None:
+    await services.handle_reject_slot(context, callback)

--- a/backend/apps/bot/handlers/slots.py
+++ b/backend/apps/bot/handlers/slots.py
@@ -6,20 +6,21 @@ from aiogram import F, Router
 from aiogram.types import CallbackQuery
 
 from .. import services
+from ..services import BotContext
 
 router = Router()
 
 
 @router.callback_query(F.data.startswith("pick_rec:"))
-async def pick_recruiter(callback: CallbackQuery) -> None:
-    await services.handle_pick_recruiter(callback)
+async def pick_recruiter(callback: CallbackQuery, context: BotContext) -> None:
+    await services.handle_pick_recruiter(context, callback)
 
 
 @router.callback_query(F.data.startswith("refresh_slots:"))
-async def refresh_slots(callback: CallbackQuery) -> None:
-    await services.handle_refresh_slots(callback)
+async def refresh_slots(callback: CallbackQuery, context: BotContext) -> None:
+    await services.handle_refresh_slots(context, callback)
 
 
 @router.callback_query(F.data.startswith("pick_slot:"))
-async def pick_slot(callback: CallbackQuery) -> None:
-    await services.handle_pick_slot(callback)
+async def pick_slot(callback: CallbackQuery, context: BotContext) -> None:
+    await services.handle_pick_slot(context, callback)

--- a/backend/apps/bot/handlers/test1.py
+++ b/backend/apps/bot/handlers/test1.py
@@ -6,10 +6,11 @@ from aiogram import F, Router
 from aiogram.types import CallbackQuery
 
 from .. import services
+from ..services import BotContext
 
 router = Router()
 
 
 @router.callback_query(F.data.startswith("t1opt:"))
-async def handle_option(callback: CallbackQuery) -> None:
-    await services.handle_test1_option(callback)
+async def handle_option(callback: CallbackQuery, context: BotContext) -> None:
+    await services.handle_test1_option(context, callback)

--- a/backend/apps/bot/handlers/test2.py
+++ b/backend/apps/bot/handlers/test2.py
@@ -6,10 +6,11 @@ from aiogram import F, Router
 from aiogram.types import CallbackQuery
 
 from .. import services
+from ..services import BotContext
 
 router = Router()
 
 
 @router.callback_query(F.data.startswith("answer_"))
-async def handle_test2(callback: CallbackQuery) -> None:
-    await services.handle_test2_answer(callback)
+async def handle_test2(callback: CallbackQuery, context: BotContext) -> None:
+    await services.handle_test2_answer(context, callback)

--- a/tests/test_bot_app_smoke.py
+++ b/tests/test_bot_app_smoke.py
@@ -1,14 +1,17 @@
 import pytest
 
-from backend.apps.bot.app import create_application
+pytest.importorskip("aiogram")
+
+from backend.apps.bot.app import BotContext, create_application
 from backend.apps.bot.services import StateManager
 
 
 @pytest.mark.asyncio
 async def test_create_application_smoke():
-    bot, dispatcher, state_manager = create_application("123456:ABCDEF")
+    context = create_application("123456:ABCDEF")
 
-    assert isinstance(state_manager, StateManager)
-    assert dispatcher is not None
+    assert isinstance(context, BotContext)
+    assert isinstance(context.state_manager, StateManager)
+    assert context.dispatcher is not None
 
-    await bot.session.close()
+    await context.bot.session.close()


### PR DESCRIPTION
## Summary
- introduce a BotContext object that encapsulates the bot, dispatcher, state manager, and reminder queues
- refactor bot services and handlers to consume the shared context via middleware instead of global state
- adjust the application factory and smoke test to build and validate the new context object

## Testing
- pytest tests/test_bot_app_smoke.py

------
https://chatgpt.com/codex/tasks/task_e_68d983b6c6348333a8bfa8ed15846d82