### PR TITLE
Fix seeding default test questions timestamps

### DIFF
--- a/backend/migrations/versions/0002_seed_defaults.py
+++ b/backend/migrations/versions/0002_seed_defaults.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import json
 from typing import Any, Dict, Iterable
 
+from datetime import datetime, timezone
+
 import sqlalchemy as sa
 
 from backend.domain.default_questions import DEFAULT_TEST_QUESTIONS
@@ -74,6 +76,8 @@ def upgrade(conn):
         sa.Column("title", sa.String),
         sa.Column("payload", sa.Text),
         sa.Column("is_active", sa.Boolean),
+        sa.Column("created_at", sa.DateTime(timezone=True)),
+        sa.Column("updated_at", sa.DateTime(timezone=True)),
     )
 
     _ensure_entries(conn, cities, unique_field="name", rows=DEFAULT_CITIES)
@@ -93,6 +97,8 @@ def upgrade(conn):
                     title=title,
                     payload=json.dumps(question, ensure_ascii=False),
                     is_active=True,
+                    created_at=datetime.now(timezone.utc),
+                    updated_at=datetime.now(timezone.utc),
                 )
             )
 


### PR DESCRIPTION
## Summary
- add timezone-aware timestamp columns to the seed helper table metadata
- populate created_at and updated_at when seeding default test questions to satisfy NOT NULL constraints

## Testing
- pytest *(fails: missing optional dependencies such as sqlalchemy and aiogram in the test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d98ab0b39c83338f944b288e4d800f