### PR TITLE
Revamp admin UI recruiters and slots views

### DIFF
--- a/backend/apps/admin_ui/routers/dashboard.py
+++ b/backend/apps/admin_ui/routers/dashboard.py
@@ -12,9 +12,15 @@ router = APIRouter()
 @router.get("/", response_class=HTMLResponse)
 async def index(request: Request):
     counts = await dashboard_counts()
-    recruiters = await list_recruiters()
+    recruiter_rows = await list_recruiters()
+    recruiters = [row["rec"] for row in recruiter_rows]
     cities = await list_cities()
     return templates.TemplateResponse(
         "index.html",
-        {"request": request, "counts": counts, "recruiters": recruiters, "cities": cities},
+        {
+            "request": request,
+            "counts": counts,
+            "recruiters": recruiters,
+            "cities": cities,
+        },
     )

--- a/backend/apps/admin_ui/routers/recruiters.py
+++ b/backend/apps/admin_ui/routers/recruiters.py
@@ -19,8 +19,12 @@ router = APIRouter(prefix="/recruiters", tags=["recruiters"])
 
 @router.get("", response_class=HTMLResponse)
 async def recruiters_list(request: Request):
-    recruiters = await list_recruiters()
-    return templates.TemplateResponse("recruiters_list.html", {"request": request, "recruiters": recruiters})
+    recruiter_rows = await list_recruiters()
+    context = {
+        "request": request,
+        "recruiter_rows": recruiter_rows,
+    }
+    return templates.TemplateResponse("recruiters_list.html", context)
 
 
 @router.get("/new", response_class=HTMLResponse)

--- a/backend/apps/admin_ui/templates/cities_list.html
+++ b/backend/apps/admin_ui/templates/cities_list.html
@@ -32,6 +32,7 @@
   </div>
 {% else %}
   <div class="card glass grain" data-tilt style="padding:0;">
+    <div class="table-wrap">
     <table id="cities_table">
       <thead>
         <tr>
@@ -170,10 +171,12 @@
       {% endfor %}
       </tbody>
     </table>
+    </div>
   </div>
 {% endif %}
 
 <style>
+  .table-wrap { overflow-x:auto; border-radius: inherit; }
   .edit-pane { border: 1px solid var(--glass-stroke); border-radius: var(--radius-lg); padding: 12px; margin: 8px 0; background: linear-gradient(180deg, rgba(255,255,255,.06), rgba(255,255,255,.02)); }
   .edit-pane .grid { display:grid; grid-template-columns: 1fr 1fr; gap: 12px; margin-bottom: 12px; }
   @media (max-width: 860px){ .edit-pane .grid { grid-template-columns: 1fr; } }

--- a/backend/apps/admin_ui/templates/cities_owners.html
+++ b/backend/apps/admin_ui/templates/cities_owners.html
@@ -18,8 +18,8 @@
 
 <!-- Панель инструментов -->
 <div class="card glass grain" data-tilt style="margin-bottom:12px; padding:12px;">
-  <div style="display:flex; gap:12px; align-items:flex-end; flex-wrap:wrap;">
-    <div class="field" style="min-width:260px;">
+  <div class="owners-toolbar">
+    <div class="field owners-field">
       <label for="search">Поиск по городу</label>
       <input id="search" type="text" placeholder="Начните вводить название города…">
     </div>
@@ -29,7 +29,7 @@
       Только без ответственного
     </label>
 
-    <div class="muted" style="margin-left:auto; display:flex; gap:10px; align-items:center; flex-wrap:wrap;">
+    <div class="muted owners-meta">
       <span>Поле в БД: <code>{{ owner_field }}</code></span>
       <span class="badge" title="Метрики">
         Города: {{ cities|length }} · Рекрутёры: {{ recruiters|length }}
@@ -102,6 +102,10 @@
     transition: background .15s ease, border-color .15s ease, box-shadow .15s ease;
     background: linear-gradient(180deg, rgba(255,255,255,.02), rgba(255,255,255,.015));
   }
+  .owners-toolbar { display:flex; gap:12px; align-items:flex-end; flex-wrap:wrap; }
+  .owners-field { flex:1 1 260px; min-width:220px; }
+  .owners-field input { width:100%; padding:10px 12px; border-radius:var(--radius-md); border:1px solid var(--field-border); background:var(--field-bg); color:inherit; box-shadow:var(--field-shadow); }
+  .owners-meta { margin-left:auto; display:flex; gap:10px; align-items:center; flex-wrap:wrap; }
   .dropzone.hover {
     background: rgba(255,255,255,.04);
     border-color: var(--ring);
@@ -110,6 +114,10 @@
   .city-card { cursor: grab; }
   .city-card:active { cursor: grabbing; }
   .city-card.dragging { opacity: .6; transform: scale(.98); }
+  @media (max-width: 760px) {
+    .owners-meta { width:100%; margin-left:0; justify-content:space-between; }
+    #board { grid-template-columns:repeat(auto-fit,minmax(220px,1fr)); }
+  }
 </style>
 
 {% raw %}

--- a/backend/apps/admin_ui/templates/recruiters_list.html
+++ b/backend/apps/admin_ui/templates/recruiters_list.html
@@ -2,34 +2,60 @@
 {% block title %}Рекрутёры{% endblock %}
 {% block content %}
 <style>
-  .panel { padding:24px; border-radius:20px; backdrop-filter:blur(30px); border:1px solid rgba(255,255,255,0.06); background:rgba(255,255,255,0.04); }
-  .panel__header { display:flex; justify-content:space-between; align-items:center; gap:16px; flex-wrap:wrap; }
-  .panel__title { margin:0; font-size:24px; font-weight:600; }
-  .panel__subtitle { margin:4px 0 0; color:var(--muted,rgba(255,255,255,0.55)); font-size:14px; }
-  .filters { display:flex; gap:12px; flex-wrap:wrap; margin:20px 0; }
-  .field { display:flex; flex-direction:column; gap:6px; min-width:200px; }
-  .field input, .field select { padding:10px 12px; border-radius:12px; border:1px solid rgba(255,255,255,0.08); background:rgba(0,0,0,0.25); color:inherit; }
-  .table-wrapper { overflow:auto; border-radius:16px; border:1px solid rgba(255,255,255,0.05); }
-  table { width:100%; border-collapse:collapse; }
-  th, td { padding:12px 16px; border-bottom:1px solid rgba(255,255,255,0.05); text-align:left; }
-  tbody tr:hover { background:rgba(255,255,255,0.03); }
-  .chip { display:inline-flex; align-items:center; padding:4px 10px; border-radius:999px; background:rgba(255,255,255,0.06); font-size:12px; margin-right:4px; }
-  .chip--ok { color:#2ecc71; }
-  .chip--warn { color:#f39c12; }
-  .chip--off { color:#95a5a6; }
-  .actions { display:flex; gap:8px; flex-wrap:wrap; }
-  .btn { padding:10px 16px; border-radius:12px; border:1px solid rgba(255,255,255,0.08); background:rgba(0,0,0,0.3); color:inherit; cursor:pointer; text-decoration:none; }
-  .btn--primary { background:linear-gradient(135deg,#4f8dfd,#8758ff); border:none; color:#fff; }
-  .muted { color:var(--muted,rgba(255,255,255,0.55)); }
+  .page { display:flex; flex-direction:column; gap:24px; }
+  .page-header { display:flex; justify-content:space-between; align-items:flex-start; gap:16px; flex-wrap:wrap; }
+  .page-header h1 { margin:0; font-size:28px; font-weight:700; }
+  .page-header p { margin:6px 0 0; color:var(--muted); max-width:420px; }
+  .page-header .actions { display:flex; gap:10px; flex-wrap:wrap; }
+
+  .filters { display:flex; gap:12px; flex-wrap:wrap; padding:16px; border-radius:var(--radius-lg); border:1px solid var(--glass-stroke); background:linear-gradient(180deg, rgba(255,255,255,.08), rgba(255,255,255,.02)); box-shadow:var(--shadow-1); }
+  .filters .field { display:flex; flex-direction:column; gap:6px; min-width:220px; flex:1 1 200px; }
+  .filters label { font-weight:600; color:var(--muted); font-size:13px; }
+  .filters input,
+  .filters select { padding:10px 12px; border-radius:var(--radius-md); border:1px solid var(--field-border); background:var(--field-bg); color:inherit; box-shadow:var(--field-shadow); }
+  .filters button { align-self:flex-end; margin-left:auto; }
+
+  .grid { display:grid; gap:16px; grid-template-columns:repeat(auto-fit, minmax(280px, 1fr)); }
+  .card-rec { display:flex; flex-direction:column; gap:12px; padding:18px; border-radius:var(--radius-lg); border:1px solid var(--glass-stroke); background:linear-gradient(180deg, rgba(255,255,255,.07), rgba(255,255,255,.015)); box-shadow:var(--shadow-2); min-height:240px; }
+  .card-rec header { display:flex; justify-content:space-between; gap:12px; align-items:flex-start; }
+  .card-rec h2 { margin:0; font-size:18px; }
+  .card-rec .meta { display:flex; flex-wrap:wrap; gap:6px; font-size:12px; color:var(--muted); }
+  .card-rec .meta span { display:inline-flex; gap:4px; align-items:center; padding:4px 8px; border-radius:999px; background:rgba(255,255,255,.06); border:1px solid rgba(255,255,255,.1); }
+  .card-rec .chips { display:flex; flex-wrap:wrap; gap:6px; }
+  .card-rec .chips span { padding:4px 8px; border-radius:999px; background:rgba(255,255,255,.05); font-size:12px; }
+  .card-rec .chips .free { color:var(--ok); }
+  .card-rec .chips .pending { color:var(--warn); }
+  .card-rec .chips .booked { color:var(--accent); }
+  .card-rec .cities { display:flex; flex-wrap:wrap; gap:6px; }
+  .card-rec .cities span { padding:4px 10px; border-radius:999px; background:rgba(255,255,255,.05); border:1px solid rgba(255,255,255,.08); font-size:12px; }
+  .card-rec footer { margin-top:auto; display:flex; gap:8px; flex-wrap:wrap; }
+  .card-rec footer .btn { flex:1 1 auto; text-align:center; }
+  .status-pill { display:inline-flex; align-items:center; gap:6px; padding:6px 12px; border-radius:999px; font-weight:600; }
+  .status-on { background:rgba(46,204,113,.12); color:#2ecc71; border:1px solid rgba(46,204,113,.25); }
+  .status-off { background:rgba(255,107,107,.12); color:#ff6b6b; border:1px solid rgba(255,107,107,.18); }
+
+  .btn { padding:10px 16px; border-radius:var(--radius-md); border:1px solid rgba(255,255,255,0.12); background:var(--btn-bg); color:inherit; cursor:pointer; text-decoration:none; display:inline-flex; justify-content:center; align-items:center; gap:6px; }
+  .btn:hover { background:var(--btn-bg-hover); }
+  .btn-primary { background:linear-gradient(135deg,#579bff,#8d5bff); border:none; color:#fff; box-shadow:var(--shadow-2); }
+  .btn-ghost { background:rgba(255,255,255,.04); border:1px solid rgba(255,255,255,.12); }
+  .empty { padding:32px; border-radius:var(--radius-lg); border:1px dashed rgba(255,255,255,.2); text-align:center; color:var(--muted); }
+
+  @media (max-width: 640px) {
+    .page-header { flex-direction:column; align-items:flex-start; }
+    .page-header .actions { width:100%; justify-content:flex-start; }
+    .card-rec footer .btn { flex:1 1 100%; }
+  }
 </style>
 
-<section class="panel">
-  <div class="panel__header">
+<section class="page">
+  <div class="page-header">
     <div>
-      <h1 class="panel__title">Рекрутёры</h1>
-      <p class="panel__subtitle">Слоты, города и статусы в одном месте</p>
+      <h1>Рекрутёры</h1>
+      <p>Следите за нагрузкой, ближайшими слотами и ответственными городами каждого рекрутёра.</p>
     </div>
-    <a class="btn btn--primary" href="/recruiters/new">Добавить рекрутёра</a>
+    <div class="actions">
+      <a class="btn btn-primary" href="/recruiters/new">Добавить рекрутёра</a>
+    </div>
   </div>
 
   <div class="filters">
@@ -37,7 +63,7 @@
       <label for="flt_query">Поиск</label>
       <input id="flt_query" type="text" placeholder="Имя, город или chat_id">
     </div>
-    <div class="field">
+    <div class="field" style="max-width:220px;">
       <label for="flt_state">Статус</label>
       <select id="flt_state">
         <option value="">Все</option>
@@ -45,78 +71,89 @@
         <option value="off">Отключённые</option>
       </select>
     </div>
-    <button class="btn" type="button" id="flt_reset">Сбросить</button>
+    <button class="btn btn-ghost" type="button" id="flt_reset">Сбросить</button>
   </div>
 
-  {% if not recruiters %}
-    <p class="muted">Записи отсутствуют. Создайте первого рекрутёра.</p>
+  {% if not recruiter_rows %}
+    <div class="empty">
+      Записи отсутствуют. Создайте первого рекрутёра, чтобы начать работу.
+      <div style="margin-top:12px;">
+        <a class="btn btn-primary" href="/recruiters/new">Добавить рекрутёра</a>
+      </div>
+    </div>
   {% else %}
-  <div class="table-wrapper">
-    <table id="recs_table">
-      <thead>
-        <tr>
-          <th>ID</th>
-          <th>Имя</th>
-          <th>TZ</th>
-          <th>Города</th>
-          <th>Слоты</th>
-          <th>Ближайший слот</th>
-          <th>Статус</th>
-          <th></th>
-        </tr>
-      </thead>
-      <tbody>
-        {% for item in recruiters %}
-          {% set r = item.rec %}
-          {% set stats = item.stats %}
-          {% set active = r.active if r.active is not none else False %}
-          <tr data-name="{{ (r.name or '')|lower }}" data-tz="{{ (r.tz or 'Europe/Moscow')|lower }}" data-chat="{{ r.tg_chat_id or '' }}" data-cities="{{ item.cities_text }}" data-active="{{ 'on' if active else 'off' }}">
-            <td>#{{ r.id }}</td>
-            <td>{{ r.name }}</td>
-            <td>{{ r.tz or 'Europe/Moscow' }}</td>
-            <td>
+    <div id="recs_grid" class="grid">
+      {% for item in recruiter_rows %}
+        {% set r = item.rec %}
+        {% set stats = item.stats %}
+        {% set active = r.active if r.active is not none else False %}
+        <article class="card-rec"
+                 data-name="{{ (r.name or '')|lower }}"
+                 data-tz="{{ (r.tz or 'Europe/Moscow')|lower }}"
+                 data-chat="{{ r.tg_chat_id or '' }}"
+                 data-cities="{{ item.cities_text }}"
+                 data-active="{{ 'on' if active else 'off' }}">
+          <header>
+            <div>
+              <h2>{{ r.name }}</h2>
+              <div class="meta">
+                <span>#{{ r.id }}</span>
+                <span title="Часовой пояс">TZ: {{ r.tz or 'Europe/Moscow' }}</span>
+                {% if r.tg_chat_id %}
+                  <span title="ID чата в Telegram">chat_id: {{ r.tg_chat_id }}</span>
+                {% endif %}
+              </div>
+            </div>
+            <span class="status-pill {{ 'status-on' if active else 'status-off' }}">
+              {{ 'Активен' if active else 'Отключен' }}
+            </span>
+          </header>
+
+          <div>
+            <div class="chips">
+              <span class="free">Свободно {{ stats.free }}</span>
+              <span class="pending">Ожидают {{ stats.pending }}</span>
+              <span class="booked">Занято {{ stats.booked }}</span>
+              <span>Всего {{ stats.total }}</span>
+            </div>
+          </div>
+
+          <div>
+            <strong style="font-size:13px;">Города</strong>
+            <div class="cities">
               {% if item.cities %}
                 {% for cname, ctz in item.cities %}
-                  <span class="chip" title="{{ ctz }}">{{ cname }}</span>
+                  <span title="{{ ctz }}">{{ cname }}</span>
                 {% endfor %}
               {% else %}
                 <span class="muted">не назначены</span>
               {% endif %}
-            </td>
-            <td>
-              <span class="chip chip--ok">свободно {{ stats.free }}</span>
-              <span class="chip">ожидают {{ stats.pending }}</span>
-              <span class="chip">занято {{ stats.booked }}</span>
-              <span class="chip">всего {{ stats.total }}</span>
-            </td>
-            <td>
-              {% if item.next_free_local %}
-                <span class="chip{% if not item.next_is_future %} chip--warn{% endif %}">{{ item.next_free_local }}</span>
-              {% else %}
-                <span class="muted">нет свободных</span>
-              {% endif %}
-            </td>
-            <td>
-              {% if active %}
-                <span class="chip chip--ok">активен</span>
-              {% else %}
-                <span class="chip chip--off">выкл</span>
-              {% endif %}
-            </td>
-            <td>
-              <div class="actions">
-                <button class="btn" type="button" data-copy="{{ r.tg_chat_id or '' }}" {% if not r.tg_chat_id %}disabled{% endif %}>Скопировать</button>
-                <a class="btn" href="/recruiters/{{ r.id }}/edit">Редактировать</a>
-                <form method="post" action="/recruiters/{{ r.id }}/delete" onsubmit="return confirm('Удалить рекрутёра {{ r.name }}?');">
-                  <button class="btn" type="submit">Удалить</button>
-                </form>
-              </div>
-            </td>
-          </tr>
-        {% endfor %}
-      </tbody>
-    </table>
-  </div>
+            </div>
+          </div>
+
+          <div>
+            <strong style="font-size:13px;">Ближайший свободный слот</strong><br>
+            {% if item.next_free_local %}
+              <span class="badge" style="margin-top:4px; display:inline-block;">
+                {{ item.next_free_local }}{% if not item.next_is_future %} · истёк{% endif %}
+              </span>
+            {% else %}
+              <span class="muted">Нет свободных слотов</span>
+            {% endif %}
+          </div>
+
+          <footer>
+            <button class="btn btn-ghost" type="button" data-copy="{{ r.tg_chat_id or '' }}" {% if not r.tg_chat_id %}disabled{% endif %}>
+              Скопировать chat_id
+            </button>
+            <a class="btn btn-ghost" href="/recruiters/{{ r.id }}/edit">Редактировать</a>
+            <form method="post" action="/recruiters/{{ r.id }}/delete" onsubmit="return confirm('Удалить рекрутёра {{ r.name }}?');" style="margin:0;">
+              <button class="btn btn-ghost" type="submit">Удалить</button>
+            </form>
+          </footer>
+        </article>
+      {% endfor %}
+    </div>
   {% endif %}
 </section>
 
@@ -127,20 +164,20 @@
   const q = $('#flt_query');
   const state = $('#flt_state');
   const reset = $('#flt_reset');
-  const rows = $$('#recs_table tbody tr');
+  const cards = $$('#recs_grid .card-rec');
   const norm = v => (v || '').toString().toLowerCase().trim();
 
   const apply = () => {
     const query = norm(q && q.value);
     const st = (state && state.value) || '';
-    rows.forEach(row => {
+    cards.forEach(card => {
       const matchText = !query ||
-        row.dataset.name?.includes(query) ||
-        row.dataset.tz?.includes(query) ||
-        row.dataset.chat?.includes(query) ||
-        row.dataset.cities?.includes(query);
-      const matchState = !st || row.dataset.active === st;
-      row.style.display = (matchText && matchState) ? '' : 'none';
+        card.dataset.name?.includes(query) ||
+        card.dataset.tz?.includes(query) ||
+        card.dataset.chat?.includes(query) ||
+        card.dataset.cities?.includes(query);
+      const matchState = !st || card.dataset.active === st;
+      card.style.display = (matchText && matchState) ? '' : 'none';
     });
   };
 
@@ -153,7 +190,7 @@
   });
   apply();
 
-  $$('.actions .btn[data-copy]').forEach(btn => {
+  $$('.card-rec button[data-copy]').forEach(btn => {
     btn.addEventListener('click', async () => {
       const value = btn.getAttribute('data-copy');
       if (!value) return;

--- a/backend/apps/admin_ui/templates/slots_list.html
+++ b/backend/apps/admin_ui/templates/slots_list.html
@@ -7,10 +7,11 @@
   .toolbar{position:sticky;top:8px;z-index:5}
   .chips{display:flex;gap:6px;flex-wrap:wrap}
   .chip{font-size:12px;padding:4px 8px;border-radius:999px;border:1px solid var(--glass-stroke);background:rgba(255,255,255,.06)}
-  .chip.btn-like{cursor:pointer}
   .chip-free{border-color:rgba(46,204,113,.45)}
   .chip-pending{border-color:rgba(241,196,15,.55)}
   .chip-booked{border-color:rgba(52,152,219,.55)}
+  #flt select{padding:8px 12px;border-radius:var(--radius-md);border:1px solid var(--field-border);background:var(--field-bg);color:inherit;box-shadow:var(--field-shadow)}
+  #flt button{border-radius:var(--radius-md);padding:10px 16px;}
 
   /* table */
   .tbl-wrap{overflow:auto;border-radius:12px}
@@ -36,12 +37,12 @@
 <h3 class="tilt" data-tilt data-tilt-max="2" data-tilt-speed="1200" data-tilt-scale="1.005" style="margin:0 0 10px 0;">Слоты</h3>
 
 <div class="card tilt toolbar" data-tilt data-tilt-glare data-tilt-max="8" data-tilt-speed="600" data-tilt-scale="1.01" style="margin-bottom:12px;">
-  <form id="flt" method="get" action="/slots" style="display:flex; gap:12px; align-items:flex-end; flex-wrap:wrap;">
-    <div>
-      <label for="recruiter_id">Рекрутёр</label><br>
-      <select id="recruiter_id" name="recruiter_id" style="min-width:240px;">
+  <form id="flt" method="get" action="/slots" style="display:flex; gap:16px; align-items:flex-end; flex-wrap:wrap;">
+    <div style="display:flex; flex-direction:column; gap:6px; min-width:220px;">
+      <label for="recruiter_id">Рекрутёр</label>
+      <select id="recruiter_id" name="recruiter_id">
         <option value="">— все —</option>
-        {% for r in recruiters %}
+        {% for r in recruiter_options %}
           <option value="{{ r.id }}" {% if filter_recruiter_id and filter_recruiter_id == r.id %}selected{% endif %}>
             {{ r.name }} ({{ r.tz or "Europe/Moscow" }})
           </option>
@@ -49,8 +50,8 @@
       </select>
     </div>
 
-    <div>
-      <label for="status">Статус</label><br>
+    <div style="display:flex; flex-direction:column; gap:6px; min-width:160px;">
+      <label for="status">Статус</label>
       <select id="status" name="status">
         <option value="">— все —</option>
         <option value="FREE" {% if filter_status == 'FREE' %}selected{% endif %}>FREE</option>
@@ -59,8 +60,8 @@
       </select>
     </div>
 
-    <div>
-      <label for="per_page">На странице</label><br>
+    <div style="display:flex; flex-direction:column; gap:6px; min-width:140px;">
+      <label for="per_page">На странице</label>
       <select id="per_page" name="per_page">
         {% for n in [10,20,50,100] %}
           <option value="{{ n }}" {% if per_page == n %}selected{% endif %}>{{ n }}</option>
@@ -68,30 +69,23 @@
       </select>
     </div>
 
-    <div>
-      <label for="q">Поиск</label><br>
-      <input id="q" type="text" placeholder="Имя кандидата / рекрутёра / TZ…" style="min-width:220px;">
-    </div>
-
-    <div style="display:flex; gap:8px; align-items:center;">
+    <div style="display:flex; gap:10px; align-items:center; flex-wrap:wrap;">
       <label class="badge" style="cursor:pointer;">
         <input id="toggle_cand_tz" type="checkbox" style="margin-right:6px;"> Время кандидата
       </label>
       <label class="badge" style="cursor:pointer;">
         <input id="only_future" type="checkbox" style="margin-right:6px;"> Только будущие
       </label>
-      <button type="submit">Фильтровать</button>
-      <a class="btn" href="/slots">Сбросить</a>
+      <button type="submit" class="btn">Показать</button>
       <a class="btn" href="/slots/new">+ Новый слот</a>
-      <button id="btn-export" class="btn" type="button">Экспорт CSV</button>
     </div>
   </form>
 
-  <div class="chips" style="margin-top:10px;">
-    <span class="chip chip-free btn-like" data-status="FREE">FREE: <b id="cnt-free">0</b></span>
-    <span class="chip chip-pending btn-like" data-status="PENDING">PENDING: <b id="cnt-pending">0</b></span>
-    <span class="chip chip-booked btn-like" data-status="BOOKED">BOOKED: <b id="cnt-booked">0</b></span>
-    <span class="chip">Всего: <b id="cnt-total">0</b></span>
+  <div class="chips" style="margin-top:12px;">
+    <span class="chip chip-free">FREE: <b id="cnt-free">{{ status_counts.FREE }}</b></span>
+    <span class="chip chip-pending">PENDING: <b id="cnt-pending">{{ status_counts.PENDING }}</b></span>
+    <span class="chip chip-booked">BOOKED: <b id="cnt-booked">{{ status_counts.BOOKED }}</b></span>
+    <span class="chip">Всего: <b id="cnt-total">{{ status_counts.total }}</b></span>
   </div>
 </div>
 
@@ -205,27 +199,22 @@
   const $ = function(s, r){ return (r||document).querySelector(s); };
   const $$= function(s, r){ return Array.from((r||document).querySelectorAll(s)); };
 
+  var rows = $$('#slots-table tbody tr');
+  var onlyFuture = $('#only_future');
+  var candTzToggle = $('#toggle_cand_tz');
+
   // Copy helper
   $$('.copyable[data-copy]').forEach(function(el){
     el.addEventListener('click', function(){
       var val = el.getAttribute('data-copy') || '';
       navigator.clipboard.writeText(val).then(function(){
-        var p = el.textContent; el.textContent='Скопировано'; setTimeout(function(){ el.textContent=p; },800);
+        var prev = el.textContent;
+        el.textContent = 'Скопировано';
+        setTimeout(function(){ el.textContent = prev; }, 900);
       }).catch(function(){ alert('Не удалось скопировать'); });
     });
   });
 
-  // State persistence
-  var LS = window.localStorage;
-  function save(k,v){ try{ LS.setItem(k, v); }catch(e){} }
-  function load(k,d){ try{ var v = LS.getItem(k); return v===null? d : v; }catch(e){ return d; } }
-
-  // Search + only future + counters
-  var q = $('#q');
-  var onlyFuture = $('#only_future');
-  var rows = $$('#slots-table tbody tr');
-
-  function norm(s){ return (s||'').toLowerCase(); }
   function isFuture(tr){
     var iso = tr.getAttribute('data-utc');
     if(!iso) return true;
@@ -233,32 +222,41 @@
     return isFinite(t) ? t >= Date.now() : true;
   }
 
-  function applyFilters(){
-    var text = norm(q ? q.value : '');
+  function refreshCounts(){
     var fut = !!(onlyFuture && onlyFuture.checked);
-    var cFree=0,cPend=0,cBook=0,cTot=0;
+    var free=0, pend=0, book=0, total=0;
     rows.forEach(function(tr){
-      var cells = tr.textContent.toLowerCase();
-      var show = (!text || cells.indexOf(text) !== -1) && (!fut || isFuture(tr));
-      tr.style.display = show ? '' : 'none';
-      if (show){
-        cTot++;
+      var visible = !fut || isFuture(tr);
+      tr.style.display = visible ? '' : 'none';
+      if(visible){
+        total++;
         var st = tr.getAttribute('data-st');
-        if(st==='FREE') cFree++; else if(st==='PENDING') cPend++; else if(st==='BOOKED') cBook++;
+        if(st==='FREE') free++; else if(st==='PENDING') pend++; else if(st==='BOOKED') book++;
       }
     });
-    $('#cnt-total').textContent=cTot; $('#cnt-free').textContent=cFree; $('#cnt-pending').textContent=cPend; $('#cnt-booked').textContent=cBook;
+    $('#cnt-total').textContent = total;
+    $('#cnt-free').textContent = free;
+    $('#cnt-pending').textContent = pend;
+    $('#cnt-booked').textContent = book;
   }
 
-  // Restore persisted UI
-  if (q) { q.value = load('slots.q', ''); }
-  if (onlyFuture){ var of = load('slots.onlyFuture','0')==='1'; onlyFuture.checked = of; }
-  var candTzToggle = $('#toggle_cand_tz');
-  if (candTzToggle){ var vis = load('slots.candTz','0')==='1'; setCandCol(vis); candTzToggle.checked = vis; }
+  if(onlyFuture){
+    onlyFuture.addEventListener('change', function(){
+      refreshCounts();
+    });
+  }
 
-  // Bind search / toggles
-  if(q) q.addEventListener('input', function(){ save('slots.q', q.value); applyFilters(); });
-  if(onlyFuture) onlyFuture.addEventListener('change', function(){ save('slots.onlyFuture', onlyFuture.checked?'1':'0'); applyFilters(); });
+  function setCandCol(show){
+    $$('.col-cand-tz').forEach(function(col){
+      col.classList.toggle('hidden-col', !show);
+    });
+  }
+  if(candTzToggle){
+    candTzToggle.addEventListener('change', function(){
+      setCandCol(candTzToggle.checked);
+    });
+    setCandCol(candTzToggle.checked);
+  }
 
   // Relative time now + update every minute
   function rel(ts){
@@ -279,44 +277,9 @@
   updateRel();
   setInterval(updateRel, 60000);
 
-  // Toggle candidate TZ column (persisted)
-  function setCandCol(vis){
-    $$('.col-cand-tz').forEach(function(c){ c.classList.toggle('hidden-col', !vis); });
-  }
-  if(candTzToggle){
-    candTzToggle.addEventListener('change', function(){ setCandCol(candTzToggle.checked); save('slots.candTz', candTzToggle.checked?'1':'0'); });
-  }
-
-  // Quick status chips -> submit server filter
-  $$('.status-chip').forEach(function(ch){ ch.style.cursor='pointer'; });
-  $$('.chip.btn-like[data-status]').forEach(function(chip){
-    chip.addEventListener('click', function(){
-      var v = chip.getAttribute('data-status');
-      var sel = $('#status'); if(sel){ sel.value = v; $('#flt').submit(); }
-    });
-  });
-
-  // Export CSV (visible rows)
-  var exportBtn = $('#btn-export');
-  if(exportBtn){
-    exportBtn.addEventListener('click', function(){
-      var headers = Array.from($('#slots-table thead tr').cells).map(function(th){ return th.textContent.trim(); });
-      var lines = [headers.join(',')];
-      $$('#slots-table tbody tr').forEach(function(tr){
-        if (tr.style.display==='none') return;
-        var cols = Array.from(tr.cells).map(function(td){ return '"'+ td.textContent.replace(/\"/g,'""').trim() +'"'; });
-        lines.push(cols.join(','));
-      });
-      var blob = new Blob([lines.join('\n')], {type:'text/csv;charset=utf-8;'});
-      var url = URL.createObjectURL(blob);
-      var a = document.createElement('a'); a.href = url; a.download = 'slots.csv'; a.click();
-      setTimeout(function(){ URL.revokeObjectURL(url); }, 5000);
-    });
-  }
-
   // Column sorting (client-side, visible rows)
-  var sortKey = load('slots.sortKey','utc');
-  var sortDir = load('slots.sortDir','asc');
+  var sortKey = 'utc';
+  var sortDir = 'asc';
 
   function applySortIndicator(){
     $$('#slots-table thead th.sortable').forEach(function(th){ th.classList.remove('active'); var d = th.querySelector('.dir'); if(d) d.textContent=''; });
@@ -350,23 +313,21 @@
       var key = th.getAttribute('data-sort');
       if (sortKey===key){ sortDir = (sortDir==='asc') ? 'desc' : 'asc'; }
       else { sortKey = key; sortDir = 'asc'; }
-      save('slots.sortKey', sortKey); save('slots.sortDir', sortDir);
       applySortIndicator(); sortRows();
+      refreshCounts();
     });
   });
 
-  // Keyboard: '/' focus search, 't' toggle candidate TZ, 'f' only future, 'esc' clear search
+  // Keyboard shortcuts: 't' toggle candidate TZ, 'f' toggle future filter
   document.addEventListener('keydown', function(e){
-    if(e.key==='/' && q){ e.preventDefault(); q.focus(); q.select(); }
     if(e.key==='t' && candTzToggle){ candTzToggle.checked = !candTzToggle.checked; candTzToggle.dispatchEvent(new Event('change')); }
     if(e.key==='f' && onlyFuture){ onlyFuture.checked = !onlyFuture.checked; onlyFuture.dispatchEvent(new Event('change')); }
-    if(e.key==='Escape' && q){ q.value=''; q.dispatchEvent(new Event('input')); }
   });
 
   // First run
   applySortIndicator();
   sortRows();
-  applyFilters();
+  refreshCounts();
 })();
 </script>
 {% endraw %}


### PR DESCRIPTION
## Summary
- disable default recruiter seeding unless the SEED_DEFAULT_RECRUITERS flag is enabled
- repair the city pages by passing recruiter entities correctly and reintroducing the owners assignment endpoint
- refresh the recruiters, slots, and city management templates with responsive layouts and simplified controls

## Testing
- pytest *(fails: missing optional dependencies such as sqlalchemy and aiogram)*

------
https://chatgpt.com/codex/tasks/task_e_68d98b57c71483339f9ef3bf0e2f6a22