### PR TITLE
Refresh admin UI theme tokens and layout

### DIFF
--- a/backend/apps/admin_ui/static/css/admin.css
+++ b/backend/apps/admin_ui/static/css/admin.css
@@ -1,0 +1,552 @@
+:root {
+  color-scheme: light;
+  /* Typography */
+  --font-sans: "SF Pro Text", "SF Pro Display", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+  --font-size-base: clamp(14px, 13px + 0.25vw, 16px);
+  --font-size-sm: clamp(13px, 12px + 0.2vw, 14px);
+  --font-size-lg: clamp(20px, 18px + 0.5vw, 28px);
+  --line-height-base: 1.55;
+  --font-weight-strong: 600;
+
+  /* Responsive rhythm */
+  --bp-sm: 36rem;
+  --bp-md: 48rem;
+  --bp-lg: 64rem;
+  --bp-2xl: 90rem;
+  --space-2xs: clamp(0.25rem, 0.2rem + 0.35vw, 0.5rem);
+  --space-xs: clamp(0.5rem, 0.4rem + 0.4vw, 0.75rem);
+  --space-sm: clamp(0.75rem, 0.6rem + 0.45vw, 1rem);
+  --space-md: clamp(1rem, 0.8rem + 0.6vw, 1.5rem);
+  --space-lg: clamp(1.5rem, 1.1rem + 0.8vw, 2.25rem);
+  --space-xl: clamp(2rem, 1.5rem + 1.4vw, 3.5rem);
+  --content-max: clamp(52rem, 88vw, 78rem);
+  --transition-duration: 200ms;
+
+  /* Light theme palette */
+  --color-bg: #f7f8fc;
+  --color-surface-soft: rgba(255, 255, 255, 0.66);
+  --color-surface-strong: rgba(255, 255, 255, 0.88);
+  --color-surface-overlay: rgba(255, 255, 255, 0.92);
+  --color-text: #101420;
+  --color-text-strong: #000410;
+  --color-muted: rgba(16, 20, 32, 0.62);
+  --color-accent: #007aff;
+  --color-accent-soft: rgba(0, 122, 255, 0.16);
+  --color-accent-strong: #335cff;
+  --color-positive: #34c759;
+  --color-warning: #ffcc00;
+  --color-danger: #ff3b30;
+  --shadow-soft: 0 2px 6px rgba(16, 20, 32, 0.08), 0 22px 45px rgba(16, 20, 32, 0.12);
+  --shadow-strong: 0 28px 60px rgba(16, 20, 32, 0.18);
+  --border-soft: rgba(16, 20, 32, 0.08);
+  --border-strong: rgba(16, 20, 32, 0.14);
+  --blur-strength: 18px;
+  --saturate-strength: 1.2;
+  --bright-strength: 1.05;
+  --layer-gradient: linear-gradient(160deg, rgba(255, 255, 255, 0.78), rgba(255, 255, 255, 0.58));
+  --app-gradient: radial-gradient(120% 120% at 15% -10%, rgba(0, 122, 255, 0.18), transparent 65%),
+                   radial-gradient(120% 120% at 90% 110%, rgba(51, 92, 255, 0.16), transparent 60%),
+                   linear-gradient(180deg, #f5f7ff 0%, #eef2fb 100%);
+  --panel-gradient: linear-gradient(120deg, rgba(255, 255, 255, 0.65), rgba(255, 255, 255, 0.4));
+
+  /* Legacy aliases */
+  --bg: var(--color-bg);
+  --fg: var(--color-text);
+  --fg-strong: var(--color-text-strong);
+  --muted: var(--color-muted);
+  --accent: var(--color-accent);
+  --accent-2: var(--color-accent-strong);
+  --ok: var(--color-positive);
+  --warn: var(--color-warning);
+  --bad: var(--color-danger);
+  --glass-tint: var(--color-surface-soft);
+  --glass-stroke: rgba(16, 20, 32, 0.1);
+  --glass-inner: var(--color-surface-overlay);
+  --glass-top: rgba(255, 255, 255, 0.95);
+  --glass-bottom: rgba(16, 20, 32, 0.08);
+  --specular: rgba(255, 255, 255, 0.85);
+  --edge-light: rgba(255, 255, 255, 0.92);
+  --edge-shadow: rgba(16, 20, 32, 0.25);
+  --shadow-1: var(--shadow-soft);
+  --shadow-2: var(--shadow-strong);
+  --shadow-3: 0 40px 70px rgba(16, 20, 32, 0.22);
+  --row-sep: rgba(16, 20, 32, 0.08);
+  --border: var(--border-soft);
+  --table-head-bg: linear-gradient(180deg, rgba(255, 255, 255, 0.9), rgba(255, 255, 255, 0.72));
+  --table-hover: rgba(0, 122, 255, 0.06);
+  --btn-bg: linear-gradient(180deg, rgba(255, 255, 255, 0.96), rgba(255, 255, 255, 0.82));
+  --btn-bg-hover: linear-gradient(180deg, rgba(255, 255, 255, 1), rgba(255, 255, 255, 0.88));
+  --btn-shadow: var(--shadow-soft);
+  --badge-bg: rgba(0, 122, 255, 0.16);
+  --badge-border: rgba(0, 122, 255, 0.25);
+  --badge-fg: color-mix(in srgb, var(--color-text) 80%, white 20%);
+  --nav-active-bg: rgba(0, 122, 255, 0.14);
+  --field-bg: rgba(255, 255, 255, 0.95);
+  --field-border: rgba(16, 20, 32, 0.12);
+  --field-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.8);
+  --radius-sm: 0.625rem;
+  --radius-md: 0.75rem;
+  --radius-lg: 1.25rem;
+}
+
+html[data-theme="dark"] {
+  color-scheme: dark;
+  --color-bg: #0f1118;
+  --color-surface-soft: rgba(22, 24, 31, 0.72);
+  --color-surface-strong: rgba(30, 33, 44, 0.8);
+  --color-surface-overlay: rgba(30, 33, 44, 0.94);
+  --color-text: #e6e8ef;
+  --color-text-strong: #f6f7ff;
+  --color-muted: rgba(230, 232, 239, 0.65);
+  --color-accent: #68a8ff;
+  --color-accent-soft: rgba(104, 168, 255, 0.18);
+  --color-accent-strong: #8e9bff;
+  --color-positive: #3ddc84;
+  --color-warning: #ffd760;
+  --color-danger: #ff6b6b;
+  --shadow-soft: 0 2px 4px rgba(0, 0, 0, 0.35), 0 18px 45px rgba(5, 8, 14, 0.45);
+  --shadow-strong: 0 36px 72px rgba(5, 8, 14, 0.55);
+  --border-soft: rgba(255, 255, 255, 0.08);
+  --border-strong: rgba(255, 255, 255, 0.16);
+  --blur-strength: 22px;
+  --saturate-strength: 1.3;
+  --bright-strength: 1.02;
+  --layer-gradient: linear-gradient(160deg, rgba(38, 42, 55, 0.82), rgba(18, 21, 31, 0.8));
+  --app-gradient: radial-gradient(110% 110% at 12% -10%, rgba(104, 168, 255, 0.18), transparent 60%),
+                   radial-gradient(120% 120% at 88% 110%, rgba(142, 155, 255, 0.16), transparent 58%),
+                   linear-gradient(180deg, #0d0f15 0%, #121621 100%);
+  --panel-gradient: linear-gradient(120deg, rgba(24, 26, 34, 0.8), rgba(18, 20, 28, 0.6));
+  --glass-stroke: rgba(255, 255, 255, 0.12);
+  --glass-bottom: rgba(0, 0, 0, 0.35);
+  --field-bg: rgba(18, 20, 28, 0.82);
+  --field-border: rgba(255, 255, 255, 0.14);
+  --field-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06);
+  --badge-bg: rgba(104, 168, 255, 0.14);
+  --badge-border: rgba(104, 168, 255, 0.22);
+  --badge-fg: rgba(230, 232, 239, 0.82);
+  --nav-active-bg: rgba(104, 168, 255, 0.18);
+  --table-head-bg: linear-gradient(180deg, rgba(30, 33, 44, 0.92), rgba(18, 20, 28, 0.8));
+  --table-hover: rgba(104, 168, 255, 0.12);
+  --btn-bg: linear-gradient(180deg, rgba(46, 51, 66, 0.78), rgba(26, 30, 40, 0.72));
+  --btn-bg-hover: linear-gradient(180deg, rgba(56, 62, 80, 0.82), rgba(26, 30, 40, 0.78));
+}
+
+@media (prefers-color-scheme: light) {
+  html:not([data-theme]) {
+    color-scheme: light;
+  }
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html, body {
+  min-height: 100%;
+}
+
+body {
+  margin: 0;
+  background: var(--app-gradient);
+  color: var(--fg);
+  font-family: var(--font-sans);
+  font-size: var(--font-size-base);
+  line-height: var(--line-height-base);
+  letter-spacing: -0.01em;
+  transition: background var(--transition-duration) ease, color var(--transition-duration) ease;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+
+body::selection,
+::selection {
+  background: color-mix(in srgb, var(--accent) 45%, transparent);
+  color: #fff;
+}
+
+.app-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: -2;
+  pointer-events: none;
+  background: var(--app-gradient);
+  transition: opacity var(--transition-duration) ease, background var(--transition-duration) ease;
+}
+
+.app-backdrop.app-backdrop--layer {
+  z-index: -1;
+  background: var(--panel-gradient);
+  opacity: 0.9;
+  filter: blur(65px) saturate(1.05);
+}
+
+.app-header {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  padding: var(--space-xs) var(--space-sm);
+  backdrop-filter: blur(24px) saturate(1.05);
+  -webkit-backdrop-filter: blur(24px) saturate(1.05);
+}
+
+.app-header__inner {
+  margin: 0 auto;
+  width: min(100%, var(--content-max));
+  border-radius: calc(var(--radius-lg) - 0.25rem);
+  border: 1px solid var(--glass-stroke);
+  background: var(--layer-gradient);
+  box-shadow: var(--shadow-soft);
+  padding: var(--space-xs) var(--space-sm);
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  flex-wrap: wrap;
+}
+
+.brand {
+  font-weight: 700;
+  font-size: clamp(1.05rem, 1rem + 0.5vw, 1.25rem);
+  color: var(--fg-strong);
+  text-decoration: none;
+}
+
+.app-nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-xs);
+}
+
+.app-nav__link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: calc(var(--space-2xs) + 2px) var(--space-sm);
+  border-radius: 999px;
+  color: var(--fg);
+  background: transparent;
+  border: 1px solid transparent;
+  transition: color var(--transition-duration) ease, background var(--transition-duration) ease, border-color var(--transition-duration) ease;
+}
+
+.app-nav__link:hover {
+  background: color-mix(in srgb, var(--accent) 12%, transparent);
+  border-color: color-mix(in srgb, var(--accent) 24%, transparent);
+  text-decoration: none;
+}
+
+.app-nav__link--active {
+  color: var(--fg-strong);
+  background: var(--nav-active-bg);
+  border-color: color-mix(in srgb, var(--accent) 32%, transparent);
+}
+
+.app-header__meta {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-xs);
+  margin-left: auto;
+  flex-wrap: wrap;
+}
+
+.app-main {
+  padding: var(--space-lg) var(--space-sm) var(--space-xl);
+}
+
+.page {
+  margin: 0 auto;
+  width: min(100%, var(--content-max));
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+}
+
+.cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: var(--space-sm);
+}
+
+.card {
+  position: relative;
+  padding: var(--space-md);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--glass-stroke);
+  background: linear-gradient(180deg, var(--glass-tint), transparent);
+  box-shadow: var(--shadow-soft);
+  color: inherit;
+  transition: transform var(--transition-duration) ease, box-shadow var(--transition-duration) ease, border-color var(--transition-duration) ease, background var(--transition-duration) ease;
+}
+
+.card:hover {
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-2);
+}
+
+.glass {
+  position: relative;
+  border-radius: inherit;
+  border: 1px solid var(--glass-stroke);
+  background: linear-gradient(180deg, var(--glass-tint), var(--glass-inner));
+  box-shadow: var(--shadow-soft);
+  transition: background var(--transition-duration) ease, border-color var(--transition-duration) ease, box-shadow var(--transition-duration) ease;
+}
+
+@supports ((backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px))) {
+  .glass {
+    backdrop-filter: blur(var(--blur-strength)) saturate(var(--saturate-strength)) brightness(var(--bright-strength));
+    -webkit-backdrop-filter: blur(var(--blur-strength)) saturate(var(--saturate-strength)) brightness(var(--bright-strength));
+    background: linear-gradient(180deg, var(--glass-tint), rgba(255, 255, 255, 0.02));
+  }
+}
+
+.grain::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background-image: radial-gradient(rgba(255, 255, 255, 0.08) 1px, transparent 0), radial-gradient(rgba(0, 0, 0, 0.08) 1px, transparent 0);
+  background-size: 3px 3px;
+  opacity: 0.05;
+  border-radius: inherit;
+  mix-blend-mode: overlay;
+}
+
+.card h4 {
+  margin: 0 0 calc(var(--space-xs) * 1.1) 0;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-strong);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--muted);
+}
+
+.card .big {
+  font-size: clamp(1.75rem, 1.4rem + 1vw, 2.4rem);
+  font-weight: 800;
+  letter-spacing: -0.02em;
+}
+
+.muted {
+  color: var(--muted);
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35em;
+  padding: calc(var(--space-2xs) + 1px) var(--space-sm);
+  border-radius: 999px;
+  border: 1px solid var(--badge-border);
+  background: var(--badge-bg);
+  color: var(--badge-fg);
+  font-size: var(--font-size-sm);
+  font-weight: 500;
+  letter-spacing: 0.02em;
+}
+
+.badge--subtle {
+  background: color-mix(in srgb, var(--badge-bg) 70%, transparent);
+  border-color: color-mix(in srgb, var(--badge-border) 65%, transparent);
+}
+
+button,
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5em;
+  padding: calc(var(--space-2xs) + 2px) calc(var(--space-sm) * 1.1);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--glass-stroke);
+  background: var(--btn-bg);
+  color: inherit;
+  cursor: pointer;
+  font: inherit;
+  box-shadow: var(--btn-shadow);
+  transition: transform var(--transition-duration) ease, box-shadow var(--transition-duration) ease, background var(--transition-duration) ease, border-color var(--transition-duration) ease;
+  position: relative;
+  text-decoration: none;
+}
+
+button:hover,
+.btn:hover {
+  background: var(--btn-bg-hover);
+  transform: translateY(-1px);
+  box-shadow: var(--shadow-2);
+  text-decoration: none;
+}
+
+button:active,
+.btn:active {
+  transform: translateY(0);
+  box-shadow: var(--shadow-1);
+}
+
+button:disabled,
+.btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
+}
+
+button:focus-visible,
+.btn:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 30%, transparent), var(--shadow-2);
+}
+
+.theme-toggle {
+  border-radius: 999px;
+  padding-inline: var(--space-sm);
+  font-weight: 600;
+  background: color-mix(in srgb, var(--btn-bg) 70%, transparent);
+}
+
+.theme-toggle[data-mode="light"] {
+  background: color-mix(in srgb, var(--btn-bg) 80%, rgba(255, 255, 255, 0.2));
+}
+
+.theme-toggle__icon {
+  font-size: 1.1rem;
+  line-height: 1;
+}
+
+.theme-toggle__label {
+  font-size: var(--font-size-sm);
+}
+
+a {
+  color: var(--accent);
+  text-decoration: none;
+  transition: color var(--transition-duration) ease;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  background: linear-gradient(180deg, var(--glass-tint), rgba(255, 255, 255, 0.02));
+  border: 1px solid var(--glass-stroke);
+  box-shadow: var(--shadow-1);
+  transition: background var(--transition-duration) ease, border-color var(--transition-duration) ease, box-shadow var(--transition-duration) ease;
+}
+
+thead th {
+  text-align: left;
+  color: var(--muted);
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  font-size: var(--font-size-sm);
+  background: var(--table-head-bg);
+  border-bottom: 1px solid var(--border);
+  padding: calc(var(--space-xs) * 0.9) var(--space-sm);
+}
+
+tbody td {
+  padding: calc(var(--space-xs) * 0.9) var(--space-sm);
+  border-bottom: 1px solid var(--row-sep);
+}
+
+tbody tr:hover {
+  background: var(--table-hover);
+}
+
+form label {
+  display: inline-block;
+  margin: var(--space-2xs) var(--space-sm) var(--space-2xs) 0;
+  font-weight: 500;
+}
+
+input,
+select,
+textarea {
+  background: var(--field-bg);
+  color: inherit;
+  border: 1px solid var(--field-border);
+  border-radius: var(--radius-md);
+  padding: calc(var(--space-2xs) + 2px) var(--space-sm);
+  box-shadow: var(--field-shadow);
+  transition: border-color var(--transition-duration) ease, box-shadow var(--transition-duration) ease, background var(--transition-duration) ease;
+}
+
+input:focus,
+select:focus,
+textarea:focus {
+  outline: none;
+  border-color: color-mix(in srgb, var(--accent) 45%, transparent);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 30%, transparent);
+}
+
+.toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-xs);
+  align-items: center;
+}
+
+.toolbar--spread {
+  justify-content: space-between;
+}
+
+.metric-grid {
+  display: grid;
+  gap: var(--space-sm);
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+.tbl-wrap {
+  overflow-x: auto;
+  border-radius: inherit;
+}
+
+@media (min-width: 48rem) {
+  .app-header__inner {
+    padding: var(--space-xs) var(--space-md);
+  }
+
+  .app-main {
+    padding: var(--space-xl) var(--space-md) var(--space-xl);
+  }
+}
+
+@media (min-width: 64rem) {
+  .app-header__inner {
+    gap: var(--space-md);
+  }
+}
+
+@media (max-width: 40rem) {
+  .theme-toggle__label {
+    display: none;
+  }
+
+  .app-header__inner {
+    align-items: flex-start;
+  }
+
+  .app-header__meta {
+    width: 100%;
+    justify-content: flex-start;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  :root {
+    --transition-duration: 0.01ms;
+  }
+
+  * {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/backend/apps/admin_ui/templates/base.html
+++ b/backend/apps/admin_ui/templates/base.html
@@ -5,678 +5,125 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>{% block title %}Админка{% endblock %} · TG Bot Admin</title>
   <link rel="icon" href="/static/favicon.ico">
+  <link rel="stylesheet" href="/static/css/admin.css">
   <script>
     (function () {
-      var storageKey = "tg-admin-theme";
+      var storageKey = 'tg-admin-theme';
       try {
         var stored = window.localStorage.getItem(storageKey);
-        var prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
-        var theme = stored || (prefersDark ? "dark" : "light");
+        var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+        var theme = stored || (prefersDark ? 'dark' : 'light');
         document.documentElement.dataset.theme = theme;
         document.documentElement.style.colorScheme = theme;
       } catch (err) {
-        document.documentElement.dataset.theme = document.documentElement.dataset.theme || "dark";
+        document.documentElement.dataset.theme = document.documentElement.dataset.theme || 'dark';
         document.documentElement.style.colorScheme = document.documentElement.dataset.theme;
       }
     })();
   </script>
-  <style>
-  :root {
-    color-scheme: dark;
-    /* base palette */
-    --bg: #0b0e13;
-    --fg: #e9eef6;
-    --fg-strong: #ffffff;
-    --muted: #aab3c2;
-
-    /* accents */
-    --accent: #69b7ff;
-    --accent-2: #b889ff;
-
-    /* halo + background */
-    --bg-gradient: radial-gradient(1200px 800px at 10% 0%, rgba(105,183,255,.10), transparent 60%),
-                    radial-gradient(1200px 900px at 100% 100%, rgba(184,137,255,.10), transparent 60%),
-                    linear-gradient(180deg, #0b0e13 0%, #0d1118 100%);
-    --halo-gradient: radial-gradient(40% 40% at 10% 0%, rgba(105,183,255,.16), transparent 60%),
-                     radial-gradient(45% 45% at 90% 85%, rgba(184,137,255,.16), transparent 62%),
-                     radial-gradient(35% 35% at 65% 35%, rgba(35,209,139,.16), transparent 65%);
-
-    /* glass tokens */
-    --glass-tint: rgba(255, 255, 255, 0.06);
-    --glass-stroke: rgba(255, 255, 255, 0.14);
-    --glass-inner: rgba(0, 0, 0, 0.25);
-    --glass-top: rgba(255, 255, 255, 0.22);
-    --glass-bottom: rgba(0, 0, 0, 0.18);
-    --specular: rgba(255, 255, 255, 0.55);
-    --edge-light: rgba(255, 255, 255, 0.35);
-    --edge-shadow: rgba(0, 0, 0, 0.45);
-
-    /* states */
-    --ok: #23d18b;
-    --warn: #ffd166;
-    --bad: #ff6b6b;
-
-    /* elevation */
-    --shadow-1: 0 1px 1px rgba(0,0,0,.25), 0 2px 6px rgba(0,0,0,.22);
-    --shadow-2: 0 8px 20px rgba(0,0,0,.35), inset 0 1px 0 rgba(255,255,255,.05);
-    --shadow-3: 0 16px 40px rgba(0,0,0,.45), inset 0 1px 0 rgba(255,255,255,.06);
-
-    /* layout */
-    --radius-lg: 16px;
-    --radius-md: 12px;
-    --radius-sm: 10px;
-
-    /* table */
-    --row-sep: rgba(255,255,255,.06);
-    --border: rgba(255,255,255,.12);
-    --table-head-bg: linear-gradient(180deg, rgba(255,255,255,.06), rgba(255,255,255,.02));
-    --table-hover: rgba(255,255,255,.05);
-
-    /* buttons & badges */
-    --btn-bg: linear-gradient(180deg, rgba(255,255,255,.10), rgba(255,255,255,.02));
-    --btn-bg-hover: linear-gradient(180deg, rgba(255,255,255,.14), rgba(255,255,255,.04));
-    --btn-shadow: var(--shadow-1), inset 0 1px 0 rgba(255,255,255,.06);
-    --badge-bg: rgba(255,255,255,.08);
-    --badge-border: var(--glass-stroke);
-    --badge-fg: var(--muted);
-    --nav-active-bg: rgba(255,255,255,.08);
-
-    /* optics */
-    --blur: 16px;
-    --sat: 1.35;
-    --bright: 1.02;
-
-    /* form controls */
-    --field-bg: rgba(12,14,19,.65);
-    --field-border: var(--glass-stroke);
-    --field-shadow: inset 0 1px 0 rgba(255,255,255,.05);
-
-    /* typography */
-    --brand-shadow: 0 1px 2px rgba(0,0,0,.35);
-  }
-
-  html[data-theme="light"] {
-    color-scheme: light;
-    --bg: #f6f7fb;
-    --fg: #0f1a2a;
-    --fg-strong: #0a1733;
-    --muted: #5b6372;
-    --accent: #2d7cff;
-    --accent-2: #6a3df5;
-    --bg-gradient: radial-gradient(1200px 840px at 0% 5%, rgba(74,118,255,.18), transparent 60%),
-                    radial-gradient(1000px 780px at 100% 100%, rgba(119,207,255,.22), transparent 55%),
-                    linear-gradient(180deg, #f6f7fb 0%, #e6ecff 100%);
-    --halo-gradient: radial-gradient(40% 40% at 8% 0%, rgba(45,124,255,.22), transparent 62%),
-                     radial-gradient(50% 45% at 92% 88%, rgba(106,61,245,.18), transparent 60%),
-                     radial-gradient(35% 35% at 65% 35%, rgba(35,209,139,.18), transparent 68%);
-    --glass-tint: rgba(255,255,255,.78);
-    --glass-stroke: rgba(12, 25, 55, 0.10);
-    --glass-inner: rgba(255,255,255,.45);
-    --glass-top: rgba(255,255,255,.92);
-    --glass-bottom: rgba(12,30,60,.08);
-    --specular: rgba(255,255,255,.85);
-    --edge-light: rgba(255,255,255,.95);
-    --edge-shadow: rgba(15,35,95,.14);
-    --shadow-1: 0 1px 1px rgba(15,35,95,.08), 0 10px 30px rgba(15,35,95,.10);
-    --shadow-2: 0 12px 30px rgba(15,35,95,.14), inset 0 1px 0 rgba(255,255,255,.45);
-    --shadow-3: 0 20px 45px rgba(15,35,95,.18), inset 0 1px 0 rgba(255,255,255,.48);
-    --row-sep: rgba(12,32,65,.10);
-    --border: rgba(12,32,65,.14);
-    --table-head-bg: linear-gradient(180deg, rgba(255,255,255,.96), rgba(255,255,255,.78));
-    --table-hover: rgba(13,41,80,.08);
-    --btn-bg: linear-gradient(180deg, rgba(255,255,255,.95), rgba(255,255,255,.78));
-    --btn-bg-hover: linear-gradient(180deg, rgba(255,255,255,1), rgba(255,255,255,.86));
-    --btn-shadow: 0 10px 26px rgba(15,35,95,.14), inset 0 1px 0 rgba(255,255,255,.85);
-    --badge-bg: rgba(45,124,255,.12);
-    --badge-border: rgba(45,124,255,.22);
-    --badge-fg: rgba(13,32,65,.76);
-    --nav-active-bg: rgba(45,124,255,.16);
-    --field-bg: rgba(255,255,255,.88);
-    --field-border: rgba(12,32,65,.16);
-    --field-shadow: inset 0 1px 0 rgba(255,255,255,.85);
-    --brand-shadow: 0 1px 0 rgba(255,255,255,.85);
-  }
-
-  @media (prefers-color-scheme: light) {
-    html:not([data-theme]) {
-      color-scheme: light;
-    }
-  }
-
-  * { box-sizing: border-box; }
-  html, body { height: 100%; }
-
-  body {
-    margin: 0;
-    background: var(--bg-gradient);
-    color: var(--fg);
-    font: 14px/1.5 system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, "Helvetica Neue", Arial, "Apple Color Emoji","Segoe UI Emoji";
-    overflow-x: hidden;
-    transition: background .35s ease, color .35s ease;
-  }
-
-  body::selection, ::selection {
-    background: color-mix(in srgb, var(--accent) 60%, transparent);
-    color: #fff;
-  }
-
-  .halo {
-    position: fixed;
-    inset: -30%;
-    z-index: -2;
-    pointer-events: none;
-    background: var(--halo-gradient);
-    filter: blur(55px) saturate(1.1);
-    transition: background .35s ease;
-  }
-
-  .grain::after {
-    content: "";
-    position: absolute;
-    inset: 0;
-    pointer-events: none;
-    background-image:
-      radial-gradient(rgba(255,255,255,.08) 1px, transparent 1px),
-      radial-gradient(rgba(0,0,0,.08) 1px, transparent 1px);
-    background-size: 2px 2px, 3px 3px;
-    mix-blend-mode: overlay;
-    opacity: .05;
-    border-radius: inherit;
-  }
-
-  a { color: var(--accent); text-decoration: none; transition: color .2s ease; }
-  a:hover { text-decoration: underline; }
-
-  .glass {
-    position: relative;
-    border-radius: var(--radius-lg);
-    background: linear-gradient(180deg, var(--glass-tint), rgba(255,255,255,0.02)),
-                linear-gradient(180deg, rgba(255,255,255,0), var(--glass-bottom));
-    border: 1px solid var(--glass-stroke);
-    box-shadow: var(--shadow-2);
-    isolation: isolate;
-    transition: background .35s ease, border-color .35s ease, box-shadow .35s ease;
-  }
-
-  @supports ((backdrop-filter: blur(var(--blur))) or (-webkit-backdrop-filter: blur(var(--blur)))) {
-    .glass {
-      backdrop-filter: blur(var(--blur)) saturate(var(--sat)) brightness(var(--bright));
-      -webkit-backdrop-filter: blur(var(--blur)) saturate(var(--sat)) brightness(var(--bright));
-      background: linear-gradient(180deg, var(--glass-tint), var(--glass-inner));
-    }
-  }
-
-  .glass::before,
-  .glass::after {
-    content: "";
-    position: absolute;
-    inset: 0;
-    border-radius: inherit;
-    pointer-events: none;
-  }
-
-  .glass::before {
-    background:
-      linear-gradient(to top left, rgba(255,255,255,.16), transparent 60%),
-      linear-gradient( 90deg,
-        transparent 0%, rgba(255,255,255,.08) 8%, transparent 14%,
-        transparent 86%, rgba(255,255,255,.06) 92%, transparent 100% );
-    mix-blend-mode: screen;
-    opacity: .8;
-  }
-
-  .glass::after {
-    box-shadow: inset 0 1px 0 rgba(255,255,255,.06), inset 0 0 0 1px rgba(255,255,255,.03);
-    background:
-      radial-gradient(120% 90% at 50% 110%, rgba(0,0,0,.18), transparent 65%),
-      radial-gradient(100% 80% at -10% 0%, rgba(255,255,255,.06), transparent 55%);
-    opacity: .9;
-  }
-
-  header {
-    position: sticky;
-    top: 0;
-    z-index: 20;
-    padding: 12px 16px 6px;
-    background: linear-gradient(180deg, rgba(0,0,0,.22), transparent 70%);
-  }
-
-  html[data-theme="light"] header {
-    background: linear-gradient(180deg, rgba(246,247,251,.92), rgba(246,247,251,0));
-  }
-
-  .nav {
-    max-width: 1100px;
-    margin: 0 auto;
-    padding: 12px 16px;
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 12px;
-    flex-wrap: wrap;
-    border-radius: var(--radius-lg);
-    box-shadow: var(--shadow-1);
-    background: linear-gradient(180deg, var(--glass-tint), rgba(255,255,255,.02));
-  }
-
-  @supports ((backdrop-filter: blur(10px)) or (-webkit-backdrop-filter: blur(10px))) {
-    .nav {
-      backdrop-filter: blur(16px) saturate(1.2);
-      -webkit-backdrop-filter: blur(16px) saturate(1.2);
-    }
-  }
-
-  .nav::before,
-  .nav::after {
-    content: "";
-    position: absolute;
-    inset: 0;
-    border-radius: inherit;
-    pointer-events: none;
-  }
-
-  .nav::before {
-    background: linear-gradient(to top left, rgba(255,255,255,.14), transparent 60%);
-    mix-blend-mode: screen;
-  }
-
-  .nav::after {
-    box-shadow: inset 0 1px 0 rgba(255,255,255,.06);
-  }
-
-  .nav__section {
-    display: flex;
-    align-items: center;
-    gap: 10px;
-    flex-wrap: wrap;
-  }
-
-  .nav__section--primary {
-    gap: 14px;
-  }
-
-  .nav .brand {
-    font-weight: 800;
-    letter-spacing: .2px;
-    color: var(--fg-strong);
-    margin-right: 6px;
-    text-shadow: var(--brand-shadow);
-    font-size: 16px;
-  }
-
-  .nav a {
-    color: var(--fg);
-    opacity: .9;
-    padding: 6px 10px;
-    border-radius: 8px;
-    transition: background .2s ease, color .2s ease, opacity .2s ease;
-  }
-
-  .nav a:hover {
-    opacity: 1;
-  }
-
-  .nav a.active {
-    color: var(--fg-strong);
-    font-weight: 600;
-    background: var(--nav-active-bg);
-    box-shadow: inset 0 1px 0 rgba(255,255,255,.08);
-    text-decoration: none;
-  }
-
-  .nav__meta {
-    margin-left: auto;
-    gap: 10px;
-  }
-
-  .nav__env {
-    margin-left: 0;
-  }
-
-  .container {
-    max-width: 1100px;
-    margin: 0 auto;
-    padding: 24px 16px 32px;
-  }
-
-  .cards {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-    gap: 16px;
-    margin: 14px 0 24px;
-  }
-
-  .card {
-    border-radius: var(--radius-lg);
-    padding: 16px;
-    position: relative;
-    overflow: hidden;
-    background: linear-gradient(180deg, var(--glass-tint), rgba(255,255,255,.02));
-    border: 1px solid var(--glass-stroke);
-    box-shadow: var(--shadow-2);
-    transition: transform .2s ease, box-shadow .2s ease;
-  }
-
-  @supports ((backdrop-filter: blur(10px)) or (-webkit-backdrop-filter: blur(10px))) {
-    .card {
-      backdrop-filter: blur(18px) saturate(1.35);
-      -webkit-backdrop-filter: blur(18px) saturate(1.35);
-    }
-  }
-
-  .card:hover {
-    transform: translateY(-1.5px);
-    box-shadow: var(--shadow-3);
-  }
-
-  .card::before,
-  .card::after {
-    content: "";
-    position: absolute;
-    inset: 0;
-    border-radius: inherit;
-    pointer-events: none;
-  }
-
-  .card::before {
-    background: linear-gradient(130deg, rgba(255,255,255,.12), transparent 40%);
-    mix-blend-mode: screen;
-    opacity: .8;
-  }
-
-  .card::after {
-    background: radial-gradient(120% 90% at 50% 110%, rgba(0,0,0,.18), transparent 65%);
-    box-shadow: inset 0 1px 0 rgba(255,255,255,.06);
-  }
-
-  .card h4 {
-    margin: 0 0 10px 0;
-    font-size: 13px;
-    color: var(--muted);
-    font-weight: 700;
-    letter-spacing: .32px;
-    text-transform: uppercase;
-  }
-
-  .card .big {
-    font-size: 30px;
-    font-weight: 900;
-    letter-spacing: .2px;
-  }
-
-  .badge {
-    padding: 4px 10px;
-    border-radius: 999px;
-    border: 1px solid var(--badge-border);
-    background: var(--badge-bg);
-    color: var(--badge-fg);
-    font-size: 12px;
-    letter-spacing: .3px;
-  }
-
-  .muted { color: var(--muted); }
-
-  table {
-    width: 100%;
-    border-collapse: collapse;
-    border-radius: var(--radius-lg);
-    overflow: hidden;
-    background: linear-gradient(180deg, var(--glass-tint), rgba(255,255,255,.015));
-    border: 1px solid var(--glass-stroke);
-    box-shadow: var(--shadow-1);
-    transition: background .35s ease, border-color .35s ease, box-shadow .35s ease;
-  }
-
-  thead th {
-    text-align: left;
-    color: var(--muted);
-    font-weight: 700;
-    letter-spacing: .3px;
-    text-transform: uppercase;
-    font-size: 12px;
-    background: var(--table-head-bg);
-    border-bottom: 1px solid var(--border);
-    padding: 10px 12px;
-  }
-
-  tbody td {
-    padding: 10px 12px;
-    border-bottom: 1px solid var(--row-sep);
-  }
-
-  tbody tr:hover {
-    background: var(--table-hover);
-  }
-
-  form label { display: inline-block; margin: 6px 12px 6px 0; }
-
-  input, select, textarea {
-    background: var(--field-bg);
-    color: var(--fg);
-    border: 1px solid var(--field-border);
-    border-radius: var(--radius-md);
-    padding: 8px 10px;
-    box-shadow: var(--field-shadow);
-    transition: border-color .2s ease, box-shadow .2s ease, background .2s ease;
-  }
-
-  input:focus, select:focus, textarea:focus {
-    outline: none;
-    border-color: var(--accent);
-    box-shadow: 0 0 0 3px color-mix(in oklab, var(--accent) 35%, transparent);
-  }
-
-  button, .btn {
-    display: inline-flex;
-    align-items: center;
-    gap: 6px;
-    padding: 9px 14px;
-    border-radius: var(--radius-md);
-    border: 1px solid var(--glass-stroke);
-    background: var(--btn-bg);
-    color: var(--fg);
-    cursor: pointer;
-    box-shadow: var(--btn-shadow);
-    transition: transform .18s ease, box-shadow .18s ease, background .18s ease, color .18s ease;
-    position: relative;
-    overflow: hidden;
-  }
-
-  button:hover, .btn:hover {
-    background: var(--btn-bg-hover);
-    transform: translateY(-.5px);
-    box-shadow: var(--shadow-2);
-    text-decoration: none;
-  }
-
-  button:active, .btn:active {
-    transform: translateY(0);
-    box-shadow: var(--shadow-1);
-  }
-
-  button:focus-visible, .btn:focus-visible {
-    outline: none;
-    box-shadow: 0 0 0 4px color-mix(in oklab, var(--accent) 32%, transparent), var(--shadow-2);
-  }
-
-  .theme-toggle {
-    border-radius: 999px;
-    font-weight: 600;
-    padding: 8px 14px;
-    background: color-mix(in srgb, var(--bg) 20%, var(--btn-bg) 80%);
-  }
-
-  .theme-toggle__icon {
-    font-size: 16px;
-    line-height: 1;
-  }
-
-  .theme-toggle__label {
-    font-size: 13px;
-  }
-
-  @media (max-width: 720px) {
-    .nav__section--primary {
-      gap: 10px;
-    }
-
-    .theme-toggle__label {
-      display: none;
-    }
-  }
-
-  @media (prefers-reduced-motion: reduce) {
-    * { animation: none !important; transition: none !important; }
-  }
-  </style>
 </head>
 <body>
-  <div aria-hidden="true" class="halo"></div>
-  <header>
-    <nav class="nav glass grain" role="navigation">
-      <div class="nav__section nav__section--primary">
-        <a class="brand" href="/">TG Bot Admin</a>
-        <a href="/" class="{% if request.url.path == '/' %}active{% endif %}">Дашборд</a>
-        <a href="/recruiters" class="{% if request.url.path.startswith('/recruiters') %}active{% endif %}">Рекрутёры</a>
-        <a href="/cities" class="{% if request.url.path.startswith('/cities') %}active{% endif %}">Города</a>
-        <a href="/slots" class="{% if request.url.path.startswith('/slots') %}active{% endif %}">Слоты</a>
-        <a href="/templates" class="{% if request.url.path.startswith('/templates') %}active{% endif %}">Шаблоны</a>
-        <a href="/questions" class="{% if request.url.path.startswith('/questions') %}active{% endif %}">Вопросы</a>
-      </div>
-      <div class="nav__section nav__meta">
-        <button id="theme-toggle" class="btn theme-toggle" type="button" aria-label="Переключить тему" aria-pressed="true">
-          <span class="theme-toggle__icon" aria-hidden="true">🌙</span>
-          <span class="theme-toggle__label">Тёмная тема</span>
+  <div aria-hidden="true" class="app-backdrop"></div>
+  <div aria-hidden="true" class="app-backdrop app-backdrop--layer"></div>
+  <header class="app-header">
+    <div class="app-header__inner glass">
+      <a class="brand" href="/">TG Bot Admin</a>
+      <nav class="app-nav" aria-label="Основная навигация">
+        <a href="/" class="app-nav__link {% if request.url.path == '/' %}app-nav__link--active{% endif %}">Дашборд</a>
+        <a href="/recruiters" class="app-nav__link {% if request.url.path.startswith('/recruiters') %}app-nav__link--active{% endif %}">Рекрутёры</a>
+        <a href="/cities" class="app-nav__link {% if request.url.path.startswith('/cities') %}app-nav__link--active{% endif %}">Города</a>
+        <a href="/slots" class="app-nav__link {% if request.url.path.startswith('/slots') %}app-nav__link--active{% endif %}">Слоты</a>
+        <a href="/templates" class="app-nav__link {% if request.url.path.startswith('/templates') %}app-nav__link--active{% endif %}">Шаблоны</a>
+        <a href="/questions" class="app-nav__link {% if request.url.path.startswith('/questions') %}app-nav__link--active{% endif %}">Вопросы</a>
+      </nav>
+      <div class="app-header__meta">
+        <button id="theme-toggle" class="theme-toggle" type="button" aria-label="Переключить тему" data-theme-toggle aria-pressed="true">
+          <span class="theme-toggle__icon" data-icon aria-hidden="true">🌙</span>
+          <span class="theme-toggle__label" data-label>Тёмная тема</span>
         </button>
-        <span class="badge nav__env">{{ request.url.hostname or 'localhost' }}</span>
+        <span class="badge badge--subtle">{{ request.url.hostname or 'localhost' }}</span>
       </div>
-    </nav>
+    </div>
   </header>
 
-  <main class="container">
-    {% block content %}{% endblock %}
+  <main class="app-main">
+    <div class="page">
+      {% block content %}{% endblock %}
+    </div>
   </main>
-<script>
-  (function(){
-    const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-    const docEl = document.documentElement;
-    const storageKey = 'tg-admin-theme';
-    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)');
-    const toggle = document.getElementById('theme-toggle');
 
-    function getStoredTheme() {
-      try { return window.localStorage.getItem(storageKey); } catch (err) { return null; }
-    }
+  <script>
+    (function () {
+      const storageKey = 'tg-admin-theme';
+      const docEl = document.documentElement;
+      const prefersDark = window.matchMedia('(prefers-color-scheme: dark)');
+      const toggle = document.querySelector('[data-theme-toggle]');
 
-    function storeTheme(theme) {
-      try { window.localStorage.setItem(storageKey, theme); } catch (err) { /* noop */ }
-    }
-
-    function applyTheme(theme, persist = true) {
-      const next = theme === 'light' ? 'light' : 'dark';
-      docEl.dataset.theme = next;
-      docEl.style.colorScheme = next;
-      if (persist) {
-        storeTheme(next);
-      }
-      reflectTheme(next);
-    }
-
-    function reflectTheme(theme) {
-      if (!toggle) { return; }
-      toggle.dataset.mode = theme;
-      toggle.setAttribute('aria-pressed', theme === 'dark');
-      const icon = theme === 'dark' ? '🌙' : '🌞';
-      const label = theme === 'dark' ? 'Тёмная тема' : 'Светлая тема';
-      toggle.querySelector('.theme-toggle__icon').textContent = icon;
-      toggle.querySelector('.theme-toggle__label').textContent = label;
-      toggle.title = 'Сменить на ' + (theme === 'dark' ? 'светлую' : 'тёмную') + ' тему';
-    }
-
-    const stored = getStoredTheme();
-    const initialTheme = stored || docEl.dataset.theme || (prefersDark.matches ? 'dark' : 'light');
-    applyTheme(initialTheme, false);
-
-    if (toggle) {
-      toggle.addEventListener('click', () => {
-        const current = docEl.dataset.theme === 'light' ? 'light' : 'dark';
-        const next = current === 'dark' ? 'light' : 'dark';
-        applyTheme(next);
-      });
-    }
-
-    if (prefersDark && typeof prefersDark.addEventListener === 'function') {
-      prefersDark.addEventListener('change', event => {
-        if (!getStoredTheme()) {
-          applyTheme(event.matches ? 'dark' : 'light', false);
+      const getStoredTheme = () => {
+        try {
+          return window.localStorage.getItem(storageKey);
+        } catch (err) {
+          return null;
         }
-      });
-    }
+      };
 
-    if (!reduceMotion) {
-      const tiltTargets = Array.from(document.querySelectorAll('[data-tilt]'));
-      tiltTargets.forEach(el => {
-        let frame, rx = 0, ry = 0, tx = 0, ty = 0;
-        const ease = 0.12;
-        const rect = () => el.getBoundingClientRect();
-        const max = 2;
-        const onMove = (e) => {
-          const r = rect();
-          const x = (e.clientX - r.left) / r.width;
-          const y = (e.clientY - r.top) / r.height;
-          rx = (0.5 - y) * max;
-          ry = (x - 0.5) * max;
-          if (!frame) loop();
-        };
-        const onLeave = () => {
-          rx = 0;
-          ry = 0;
-          if (!frame) loop();
-        };
-        function loop(){
-          frame = requestAnimationFrame(()=>{
-            tx += (rx - tx) * ease;
-            ty += (ry - ty) * ease;
-            el.style.transform = `perspective(900px) rotateX(${tx}deg) rotateY(${ty}deg)`;
-            if (Math.abs(tx - rx) > 0.01 || Math.abs(ty - ry) > 0.01) {
-              loop();
-            } else {
-              cancelAnimationFrame(frame);
-              frame = null;
-            }
-          });
+      const storeTheme = (theme) => {
+        try {
+          window.localStorage.setItem(storageKey, theme);
+        } catch (err) {
+          /* noop */
         }
-        el.addEventListener('mousemove', onMove);
-        el.addEventListener('mouseleave', onLeave);
-      });
+      };
 
-      const rippleTargets = document.querySelectorAll('button, .btn');
-      rippleTargets.forEach(btn => {
-        btn.style.position = btn.style.position || 'relative';
-        btn.style.overflow = 'hidden';
-        btn.addEventListener('click', (e) => {
-          const d = Math.max(btn.clientWidth, btn.clientHeight);
-          const r = document.createElement('span');
-          r.style.position = 'absolute';
-          r.style.width = r.style.height = d + 'px';
-          r.style.left = (e.offsetX - d/2) + 'px';
-          r.style.top = (e.offsetY - d/2) + 'px';
-          r.style.borderRadius = '50%';
-          r.style.background = 'radial-gradient(circle, rgba(255,255,255,.30) 0%, rgba(255,255,255,0) 60%)';
-          r.style.transform = 'scale(0)';
-          r.style.opacity = '0.7';
-          r.style.pointerEvents = 'none';
-          r.style.transition = 'transform .45s ease, opacity .6s ease';
-          btn.appendChild(r);
-          requestAnimationFrame(() => {
-            r.style.transform = 'scale(1)';
-            r.style.opacity = '0';
-          });
-          setTimeout(() => r.remove(), 620);
+      const reflectTheme = (theme) => {
+        if (!toggle) {
+          return;
+        }
+        toggle.dataset.mode = theme;
+        toggle.setAttribute('aria-pressed', theme === 'dark');
+        const icon = theme === 'dark' ? '🌙' : '🌞';
+        const label = theme === 'dark' ? 'Тёмная тема' : 'Светлая тема';
+        const iconNode = toggle.querySelector('[data-icon]');
+        const labelNode = toggle.querySelector('[data-label]');
+        if (iconNode) {
+          iconNode.textContent = icon;
+        }
+        if (labelNode) {
+          labelNode.textContent = label;
+        }
+        toggle.title = theme === 'dark' ? 'Включить светлую тему' : 'Включить тёмную тему';
+      };
+
+      const applyTheme = (theme, persist = true) => {
+        const next = theme === 'light' ? 'light' : 'dark';
+        docEl.dataset.theme = next;
+        docEl.style.colorScheme = next;
+        if (persist) {
+          storeTheme(next);
+        }
+        reflectTheme(next);
+      };
+
+      const stored = getStoredTheme();
+      const initialTheme = stored || docEl.dataset.theme || (prefersDark.matches ? 'dark' : 'light');
+      applyTheme(initialTheme, false);
+
+      if (toggle) {
+        toggle.addEventListener('click', () => {
+          const current = docEl.dataset.theme === 'dark' ? 'dark' : 'light';
+          const next = current === 'dark' ? 'light' : 'dark';
+          applyTheme(next);
         });
-      });
-    }
-  })();
-</script>
+      }
+
+      if (prefersDark && typeof prefersDark.addEventListener === 'function') {
+        prefersDark.addEventListener('change', (event) => {
+          if (!getStoredTheme()) {
+            applyTheme(event.matches ? 'dark' : 'light', false);
+          }
+        });
+      }
+    })();
+  </script>
 </body>
 </html>

--- a/backend/apps/admin_ui/templates/cities_list.html
+++ b/backend/apps/admin_ui/templates/cities_list.html
@@ -21,7 +21,7 @@
 </div>
 
 {% if not cities %}
-  <div class="card glass grain" data-tilt style="padding:16px;">
+  <div class="card glass grain" style="padding:16px;">
     <h4>Пусто</h4>
     <p class="muted">Пока нет ни одного города. Нажмите «Новый город», чтобы добавить первый.</p>
     <div style="margin-top:8px;">

--- a/backend/apps/admin_ui/templates/cities_new.html
+++ b/backend/apps/admin_ui/templates/cities_new.html
@@ -2,7 +2,7 @@
 {% block title %}Новый город{% endblock %}
 {% block content %}
 
-<div class="card glass grain" data-tilt style="margin: 8px 0 16px;">
+<div class="card glass grain" style="margin: 8px 0 16px;">
   <h3 style="margin:0 0 12px 0; display:flex; align-items:center; gap:10px;">
     🏙️ Новый город
     <span class="badge" title="Часовой пояс">TZ</span>
@@ -17,8 +17,7 @@
              name="name"
              placeholder="Новосибирск"
              required
-             autofocus
-             style="width:100%;">
+             autofocus style="width:100%;">
       <p class="muted" style="margin:6px 0 0;">
         Поддерживается кириллица. Для известных городов таймзона подставится автоматически (можно изменить вручную).
       </p>
@@ -36,8 +35,7 @@
              inputmode="text"
              pattern="[A-Za-z_]+(?:\/[A-Za-z_\-]+)+"
              title="Например: Europe/Moscow, Europe/Samara, Asia/Novosibirsk"
-             required
-             style="width:100%;">
+             required style="width:100%;">
       <datalist id="tz-list">
         <option value="Europe/Moscow"></option>
         <option value="Europe/Samara"></option>

--- a/backend/apps/admin_ui/templates/index.html
+++ b/backend/apps/admin_ui/templates/index.html
@@ -3,7 +3,7 @@
 {% block content %}
 
 <!-- Тулбар дашборда: заголовок + быстрые действия в Liquid Glass -->
-<div class="card glass grain" data-tilt style="margin: 0 0 12px; padding: 12px;">
+<div class="card glass grain" style="margin: 0 0 12px; padding: 12px;">
   <div style="display:flex; gap:8px; flex-wrap:wrap; align-items:center;">
     <h3 style="margin:0;">Дашборд</h3>
     <div style="margin-left:auto; display:flex; gap:8px; flex-wrap:wrap;">
@@ -16,26 +16,26 @@
 </div>
 
 <div class="cards">
-  <div class="card glass grain" data-tilt tabindex="0">
+  <div class="card glass grain" tabindex="0">
     <h4>Рекрутёры</h4>
     <div class="big">{{ counts.recruiters }}</div>
     <p style="margin:6px 0 0;"><a href="/recruiters">Перейти к списку</a></p>
   </div>
 
-  <div class="card glass grain" data-tilt tabindex="0">
+  <div class="card glass grain" tabindex="0">
     <h4>Города</h4>
     <div class="big">{{ counts.cities }}</div>
     <p style="margin:6px 0 0;"><a href="/cities">Перейти к списку</a></p>
   </div>
 
-  <div class="card glass grain" data-tilt tabindex="0">
+  <div class="card glass grain" tabindex="0">
     <h4>Слоты всего</h4>
     <div class="big">{{ counts.slots_total }}</div>
     <p class="badge">FREE: {{ counts.slots_free }} · PENDING: {{ counts.slots_pending }} · BOOKED: {{ counts.slots_booked }}</p>
     <p style="margin:6px 0 0;"><a href="/slots">Перейти к слотам</a></p>
   </div>
 
-  <div class="card glass grain" data-tilt tabindex="0">
+  <div class="card glass grain" tabindex="0">
     <h4>Шаблоны</h4>
     <div class="big">{{ counts.templates|default(0) }}</div>
     <p style="margin:6px 0 0;"><a href="/templates">Перейти к списку</a></p>
@@ -43,7 +43,7 @@
 </div>
 
 <div style="display:grid; grid-template-columns:1fr 1fr; gap:16px;">
-  <div class="card glass grain" data-tilt tabindex="0" style="padding:0;">
+  <div class="card glass grain" tabindex="0" style="padding:0;">
     <div style="padding:14px;">
       <h4 style="margin:0 0 10px 0;">Активные рекрутёры</h4>
       {% set actives = recruiters | selectattr('active') | list %}
@@ -75,7 +75,7 @@
     </div>
   </div>
 
-  <div class="card glass grain" data-tilt tabindex="0" style="padding:0;">
+  <div class="card glass grain" tabindex="0" style="padding:0;">
     <div style="padding:14px;">
       <h4 style="margin:0 0 10px 0;">Города в работе</h4>
       {% if not cities %}

--- a/backend/apps/admin_ui/templates/questions_list.html
+++ b/backend/apps/admin_ui/templates/questions_list.html
@@ -13,7 +13,7 @@
 
 {% if tests %}
   {% for test in tests %}
-    <section class="glass" style="padding:18px; margin-bottom:20px;" data-tilt>
+    <section class="glass" style="padding:18px; margin-bottom:20px;">
       <header style="display:flex; align-items:center; gap:12px; margin-bottom:14px;">
         <h2 style="margin:0; font-size:20px;">{{ test.title }}</h2>
         <span class="badge">{{ test.test_id }}</span>

--- a/backend/apps/admin_ui/templates/slots_list.html
+++ b/backend/apps/admin_ui/templates/slots_list.html
@@ -34,9 +34,9 @@
   tbody tr:hover td{background:rgba(255,255,255,.03)}
 </style>
 
-<h3 class="tilt" data-tilt data-tilt-max="2" data-tilt-speed="1200" data-tilt-scale="1.005" style="margin:0 0 10px 0;">Слоты</h3>
+<h3 style="margin:0 0 10px 0;">Слоты</h3>
 
-<div class="card tilt toolbar" data-tilt data-tilt-glare data-tilt-max="8" data-tilt-speed="600" data-tilt-scale="1.01" style="margin-bottom:12px;">
+<div class="card toolbar" style="margin-bottom:12px;">
   <form id="flt" method="get" action="/slots" style="display:flex; gap:16px; align-items:flex-end; flex-wrap:wrap;">
     <div style="display:flex; flex-direction:column; gap:6px; min-width:220px;">
       <label for="recruiter_id">Рекрутёр</label>
@@ -90,19 +90,19 @@
 </div>
 
 {% if not slots %}
-  <div class="card tilt" data-tilt data-tilt-glare data-tilt-max="6" data-tilt-speed="500">
+  <div class="card">
     <h4>Пусто</h4>
     <p>Слотов по выбранным условиям нет.</p>
   </div>
 {% else %}
-  <div class="card tilt tbl-wrap" data-tilt data-tilt-glare data-tilt-max="6" data-tilt-speed="600">
+  <div class="card tbl-wrap">
     <table id="slots-table">
       <thead>
         <tr>
           <th class="sortable" data-sort="id"     title="Сортировать по ID">ID <span class="dir"></span></th>
           <th class="sortable" data-sort="rec"    title="Сортировать по рекрутёру">Рекрутёр <span class="dir"></span></th>
-          <th class="sortable" data-sort="utc"    style="width:160px;" title="Сортировать по UTC">UTC <span class="dir"></span></th>
-          <th                                   style="width:210px;">Локальное (TZ рекрутёра)</th>
+          <th class="sortable" data-sort="utc" style="width:160px;" title="Сортировать по UTC">UTC <span class="dir"></span></th>
+          <th style="width:210px;">Локальное (TZ рекрутёра)</th>
           <th style="width:210px;" class="col-cand-tz">Локальное (TZ кандидата)</th>
           <th class="sortable" data-sort="status" style="width:120px;" title="Сортировать по статусу">Статус <span class="dir"></span></th>
           <th class="sortable" data-sort="cand"   title="Сортировать по кандидату">Кандидат <span class="dir"></span></th>
@@ -168,7 +168,7 @@
   </div>
 
   <!-- пагинация -->
-  <div class="tilt" data-tilt data-tilt-max="3" data-tilt-speed="800" style="display:flex; align-items:center; gap:8px; margin-top:10px; flex-wrap:wrap;">
+  <div style="display:flex; align-items:center; gap:8px; margin-top:10px; flex-wrap:wrap;">
     {% set qrecr = '&recruiter_id=' ~ filter_recruiter_id if filter_recruiter_id else '' %}
     {% set qstat = '&status=' ~ filter_status if filter_status else '' %}
     {% set qpp = '&per_page=' ~ per_page if per_page else '' %}

--- a/backend/apps/admin_ui/templates/slots_new.html
+++ b/backend/apps/admin_ui/templates/slots_new.html
@@ -37,7 +37,7 @@
   .kbd { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size:12px; border:1px solid var(--glass-stroke); padding:1px 6px; border-radius:6px; background:rgba(255,255,255,.06); }
 </style>
 
-<div class="tilt" data-tilt data-tilt-max="6" data-tilt-speed="500" style="margin:0 0 10px 0;">
+<div style="margin:0 0 10px 0;">
   <div style="display:flex; align-items:center; gap:10px; flex-wrap:wrap;">
     <h3 style="margin:0;">➕ Новый слот</h3>
     <div class="segmented" role="tablist" aria-label="Режим создания">
@@ -50,7 +50,7 @@
 </div>
 
 {% if not recruiters %}
-  <div class="card glass tilt" data-tilt data-tilt-max="8" data-tilt-speed="450">
+  <div class="card glass">
     <h4 style="margin:0 0 8px 0;">Нет рекрутёров</h4>
     <p class="muted" style="margin:0 0 10px 0;">Сначала добавьте рекрутёра, затем создайте слот.</p>
     <p style="margin:0;"><a class="btn" href="/recruiters/new">+ Добавить рекрутёра</a></p>
@@ -58,7 +58,7 @@
 {% else %}
 
 <!-- ==== ПАНЕЛЬ «ОДИН СЛОТ» ==== -->
-<section id="panel-one" class="card glass tilt" data-tilt data-tilt-max="8" data-tilt-speed="450" data-tilt-glare data-tilt-max-glare="0.18" style="margin-bottom:14px;">
+<section id="panel-one" class="card glass" style="margin-bottom:14px;">
   <form method="post" action="/slots/create" autocomplete="off" id="form-one">
     <div class="row2">
       <div class="field">
@@ -110,7 +110,7 @@
 </section>
 
 <!-- ==== ПАНЕЛЬ «СЕРИЯ» ==== -->
-<section id="panel-bulk" class="card glass tilt" data-tilt data-tilt-max="8" data-tilt-speed="450" data-tilt-glare data-tilt-max-glare="0.18" hidden>
+<section id="panel-bulk" class="card glass" hidden>
   <form method="post" action="/slots/bulk_create" autocomplete="off" id="form-bulk">
     <p class="hint" style="margin:0 0 6px;">Создаст слоты каждый будний день с 10:00 до 16:00, перерыв 12:00–13:00, шаг 30 минут. Дубликаты пропускаются.</p>
 

--- a/backend/apps/admin_ui/templates/templates_edit.html
+++ b/backend/apps/admin_ui/templates/templates_edit.html
@@ -3,7 +3,7 @@
 {% block content %}
 <h3 style="margin-top:0;">Редактирование шаблона <span class="badge">#{{ tmpl.id }}</span></h3>
 
-<div class="card glass tilt" data-tilt data-tilt-max="6" data-tilt-speed="400" data-tilt-glare data-tilt-max-glare="0.15">
+<div class="card glass">
   <form method="post" action="/templates/{{ tmpl.id }}/update" autocomplete="off" id="tmplForm">
     <!-- Тип шаблона -->
     <div class="field" style="display:flex; align-items:center; gap:10px; margin-bottom:10px;">
@@ -61,8 +61,7 @@
     <!-- Текст шаблона -->
     <div class="field" style="margin-top:12px;">
       <label for="text">Текст шаблона</label>
-      <textarea id="text" name="text" rows="14" required
-                style="width:100%; font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;">{{ tmpl.text_field }}</textarea>
+      <textarea id="text" name="text" rows="14" required style="width:100%; font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;">{{ tmpl.text_field }}</textarea>
       <p class="muted" style="margin:6px 0 0;">
         Поддерживаются плейсхолдеры:
         {% raw %}

--- a/backend/apps/admin_ui/templates/templates_list.html
+++ b/backend/apps/admin_ui/templates/templates_list.html
@@ -23,7 +23,7 @@
   </div>
 </div>
 
-<section class="card glass tilt" data-tilt data-tilt-max="4" data-tilt-speed="400" style="margin-bottom:18px;">
+<section class="card glass" style="margin-bottom:18px;">
   <header style="display:flex; justify-content:space-between; align-items:center; gap:10px; flex-wrap:wrap;">
     <div>
       <h3 style="margin:0;">Глобальные шаблоны</h3>

--- a/backend/apps/admin_ui/templates/templates_new.html
+++ b/backend/apps/admin_ui/templates/templates_new.html
@@ -4,7 +4,7 @@
 <h3 style="margin:0 0 12px 0;">Новый шаблон</h3>
 
 <form id="tmplForm" method="post" action="/templates/create" autocomplete="off">
-  <div class="glass tilt" style="padding:16px; max-width:860px; margin:0;">
+  <div class="glass" style="padding:16px; max-width:860px; margin:0;">
     {% set has_cities = (cities|length) > 0 %}
 
     <!-- Тип шаблона -->


### PR DESCRIPTION
## Summary
- add a tokenized admin stylesheet with SF-inspired typography, dual light/dark palettes, and responsive spacing
- simplify the base layout with the new navigation bar, backdrop panels, and theme toggle bound to the new tokens
- drop legacy tilt/ripple hooks from admin templates so cards, tables, and controls rely on the refreshed tokens

## Testing
- pytest *(fails: missing aiogram and sqlalchemy dependencies in the test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da18d5d4908333956cbd28a58dbcf3