### PR TITLE
refactor: unify admin list layouts and styles

### DIFF
--- a/backend/apps/admin_ui/static/css/lists.css
+++ b/backend/apps/admin_ui/static/css/lists.css
@@ -1,0 +1,709 @@
+/* Shared layout primitives for admin lists */
+.page {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.page-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.page-title {
+  margin: 0;
+  font-size: 28px;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
+
+.page-description {
+  margin: 6px 0 0;
+  max-width: 520px;
+  color: var(--muted);
+}
+
+.page-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: center;
+}
+
+.page-actions .btn {
+  flex: 0 0 auto;
+}
+
+.section-title {
+  margin: 0 0 6px;
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0.32px;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+/* Toolbar */
+.list-toolbar {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: 18px;
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--glass-stroke);
+  background: linear-gradient(180deg, rgba(255,255,255,.08), rgba(255,255,255,.02));
+  box-shadow: var(--shadow-1);
+  isolation: isolate;
+}
+
+.list-toolbar--sticky {
+  position: sticky;
+  top: 12px;
+  z-index: 5;
+}
+
+.list-toolbar__form {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  gap: 16px;
+}
+
+.list-toolbar__filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  flex: 1 1 auto;
+}
+
+.list-toolbar__actions,
+.list-toolbar__mass {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: center;
+}
+
+.list-toolbar__actions {
+  margin-left: auto;
+}
+
+.list-toolbar__chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 180px;
+  flex: 1 1 200px;
+}
+
+.form-field--narrow {
+  min-width: 140px;
+  flex: 0 1 160px;
+}
+
+.form-field--wide {
+  flex: 1 1 260px;
+}
+
+.field-stack {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: center;
+}
+
+.form-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px;
+  border-radius: 999px;
+  border: 1px solid var(--glass-stroke);
+  background: rgba(255,255,255,.05);
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.form-toggle input {
+  accent-color: var(--accent);
+}
+
+/* Chips */
+.chip-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  border: 1px solid var(--glass-stroke);
+  background: rgba(255,255,255,.05);
+  font-size: 12px;
+  letter-spacing: .25px;
+}
+
+.chip__value {
+  font-weight: 600;
+  font-size: 12px;
+}
+
+.chip--success {
+  border-color: color-mix(in srgb, var(--ok) 45%, transparent);
+  color: var(--ok);
+}
+
+.chip--warning {
+  border-color: color-mix(in srgb, var(--warn) 45%, transparent);
+  color: var(--warn);
+}
+
+.chip--info {
+  border-color: color-mix(in srgb, var(--accent) 45%, transparent);
+  color: var(--accent);
+}
+
+.chip--danger {
+  border-color: color-mix(in srgb, var(--bad) 45%, transparent);
+  color: var(--bad);
+}
+
+/* Buttons */
+.btn-primary {
+  background: linear-gradient(135deg, var(--accent), var(--accent-2));
+  border-color: transparent;
+  color: #fff;
+}
+
+.btn-ghost {
+  background: rgba(255,255,255,.04);
+  border-color: rgba(255,255,255,.18);
+}
+
+.btn-danger {
+  background: linear-gradient(135deg, rgba(255,107,107,.85), rgba(255,107,107,.65));
+  border-color: rgba(255,107,107,.55);
+  color: #fff;
+}
+
+.btn-soft {
+  background: rgba(255,255,255,.08);
+  border-color: rgba(255,255,255,.16);
+}
+
+.btn--grow {
+  flex: 1 1 160px;
+  justify-content: center;
+}
+
+.btn--small {
+  padding: 6px 10px;
+  font-size: 13px;
+}
+
+.btn--ghost-link {
+  background: transparent;
+  border-color: transparent;
+  box-shadow: none;
+  padding-inline: 0;
+}
+
+button:disabled,
+.btn[disabled] {
+  opacity: .55;
+  pointer-events: none;
+}
+
+/* Status badges */
+.status-badge,
+.status-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  border-radius: 999px;
+  font-weight: 600;
+  font-size: 12px;
+  letter-spacing: .3px;
+  border: 1px solid transparent;
+  background: rgba(255,255,255,.06);
+}
+
+.status-badge[data-tone="success"],
+.status-pill[data-state="on"] {
+  color: var(--ok);
+  border-color: color-mix(in srgb, var(--ok) 40%, transparent);
+  background: color-mix(in srgb, var(--ok) 18%, transparent);
+}
+
+.status-badge[data-tone="warning"],
+.status-pill[data-state="pending"] {
+  color: var(--warn);
+  border-color: color-mix(in srgb, var(--warn) 40%, transparent);
+  background: color-mix(in srgb, var(--warn) 18%, transparent);
+}
+
+.status-badge[data-tone="info"],
+.status-pill[data-state="booked"] {
+  color: var(--accent);
+  border-color: color-mix(in srgb, var(--accent) 40%, transparent);
+  background: color-mix(in srgb, var(--accent) 18%, transparent);
+}
+
+.status-badge[data-tone="danger"],
+.status-pill[data-state="off"] {
+  color: var(--bad);
+  border-color: color-mix(in srgb, var(--bad) 40%, transparent);
+  background: color-mix(in srgb, var(--bad) 18%, transparent);
+}
+
+/* Card grids */
+.card-grid {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.card-title {
+  margin: 0;
+  font-size: 20px;
+  font-weight: 600;
+}
+
+.recruiter-card {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: 18px;
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--glass-stroke);
+  background: linear-gradient(180deg, rgba(255,255,255,.07), rgba(255,255,255,.02));
+  box-shadow: var(--shadow-1);
+  min-height: 240px;
+}
+
+.recruiter-card__header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: flex-start;
+}
+
+.recruiter-card__name {
+  margin: 0;
+  font-size: 20px;
+}
+
+.meta-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.chip-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.badge-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.recruiter-card__footer {
+  margin-top: auto;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.section-block {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.section-block .section-title {
+  margin-bottom: 0;
+}
+
+.inline-form {
+  margin: 0;
+}
+
+/* Tables */
+.list-table-wrapper {
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  box-shadow: var(--shadow-1);
+}
+
+.list-table {
+  width: 100%;
+  border-collapse: collapse;
+  background: linear-gradient(180deg, rgba(255,255,255,.06), rgba(255,255,255,.02));
+}
+
+.list-table thead th {
+  position: sticky;
+  top: 0;
+  background: linear-gradient(180deg, rgba(255,255,255,.12), rgba(255,255,255,.04));
+  text-align: left;
+  color: var(--muted);
+  font-weight: 700;
+  text-transform: uppercase;
+  font-size: 11px;
+  letter-spacing: .35px;
+  padding: 12px 14px;
+  border-bottom: 1px solid var(--border);
+}
+
+.list-table tbody td {
+  padding: 12px 14px;
+  border-bottom: 1px solid var(--row-sep);
+  vertical-align: top;
+}
+
+.list-table tbody tr:hover {
+  background: rgba(255,255,255,.03);
+}
+
+.list-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.list-table .is-optional {
+  color: var(--muted);
+}
+
+.list-table .cell-actions {
+  text-align: right;
+}
+
+.list-table .cell-actions .btn {
+  justify-content: flex-end;
+}
+
+.hidden-col {
+  display: none !important;
+}
+
+.copyable {
+  cursor: pointer;
+  border-bottom: 1px dashed rgba(255,255,255,.35);
+}
+
+.copyable:hover {
+  opacity: .85;
+}
+
+.list-table__details {
+  display: none;
+}
+
+.table-empty {
+  text-align: center;
+  padding: 20px;
+}
+
+/* Pagination */
+.pagination {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+}
+
+.pagination .badge {
+  margin-right: 4px;
+}
+
+/* City list */
+.city-collection {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.city-card {
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--glass-stroke);
+  background: linear-gradient(180deg, rgba(255,255,255,.06), rgba(255,255,255,.02));
+  padding: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.city-card__header {
+  display: grid;
+  gap: 12px;
+}
+
+.city-card__title {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+  font-size: 18px;
+  font-weight: 600;
+}
+
+.city-card__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.city-card__actions {
+  display: flex;
+  gap: 10px;
+}
+
+.city-card__details {
+  display: none;
+  flex-direction: column;
+  gap: 16px;
+  border-top: 1px solid var(--glass-stroke);
+  padding-top: 14px;
+}
+
+.city-card.open .city-card__details {
+  display: flex;
+}
+
+.form-grid {
+  display: grid;
+  gap: 14px;
+}
+
+@media (min-width: 840px) {
+  .city-card__header {
+    grid-template-columns: minmax(0, 1.4fr) minmax(0, 1fr) auto;
+    align-items: center;
+  }
+
+  .city-card__actions {
+    justify-content: flex-end;
+  }
+
+  .form-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.stage-controls,
+.form-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: center;
+}
+
+.save-status {
+  display: none;
+}
+
+.stage-flow {
+  margin: 12px 0 0;
+  padding-left: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.city-card .stage-field,
+.template-form .stage-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.template-form textarea {
+  min-height: 140px;
+  resize: vertical;
+}
+
+.info-badge {
+  margin-top: 8px;
+  display: inline-flex;
+  gap: 8px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.save-status.ok {
+  color: var(--ok);
+}
+
+.save-status.err {
+  color: var(--bad);
+}
+
+/* Question list */
+.test-section {
+  padding: 20px;
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--glass-stroke);
+  background: linear-gradient(180deg, rgba(255,255,255,.07), rgba(255,255,255,.02));
+  margin-bottom: 20px;
+}
+
+.test-section__header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 14px;
+}
+
+.test-section__meta {
+  margin-left: auto;
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.question-title {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 600;
+}
+
+.question-meta {
+  font-size: 13px;
+  color: var(--muted);
+}
+
+.question-meta--small {
+  font-size: 12px;
+  color: var(--muted);
+  margin-top: 4px;
+}
+
+/* Responsive table conversions */
+@media (max-width: 960px) {
+  .list-toolbar__actions {
+    width: 100%;
+    justify-content: flex-start;
+    margin-left: 0;
+  }
+
+  .list-table--responsive thead {
+    display: none;
+  }
+
+  .list-table--responsive tbody tr {
+    display: block;
+    margin-bottom: 12px;
+    border: 1px solid var(--glass-stroke);
+    border-radius: var(--radius-lg);
+    background: linear-gradient(180deg, rgba(255,255,255,.07), rgba(255,255,255,.02));
+    box-shadow: var(--shadow-1);
+  }
+
+  .list-table--responsive tbody td {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+    gap: 4px;
+    border-bottom: 1px solid rgba(255,255,255,.04);
+  }
+
+  .list-table--responsive tbody td:last-child {
+    border-bottom: none;
+  }
+
+  .list-table--responsive tbody td::before {
+    content: attr(data-label);
+    font-weight: 600;
+    color: var(--muted);
+    font-size: 12px;
+    letter-spacing: .3px;
+    text-transform: uppercase;
+  }
+
+  .list-table--responsive tbody td[data-label=""]::before {
+    content: '';
+    display: none;
+  }
+
+  .list-table--responsive .is-optional,
+  .list-table--responsive .cell-actions {
+    display: none;
+  }
+
+  .list-table__details {
+    display: block;
+  }
+
+  .list-table__details details {
+    border-top: 1px solid rgba(255,255,255,.06);
+    margin-top: 6px;
+    padding-top: 6px;
+  }
+
+  .list-table__details summary {
+    cursor: pointer;
+    list-style: none;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-weight: 600;
+  }
+
+  .list-table__details summary::after {
+    content: '▾';
+    font-size: 12px;
+  }
+
+  .list-table__details[open] summary::after {
+    transform: rotate(180deg);
+  }
+}
+
+@media (max-width: 640px) {
+  .page-header {
+    flex-direction: column;
+  }
+
+  .page-actions {
+    width: 100%;
+    justify-content: flex-start;
+  }
+
+  .recruiter-card__footer .btn {
+    flex: 1 1 100%;
+  }
+
+  .list-toolbar {
+    padding: 16px;
+  }
+
+  .form-field {
+    flex: 1 1 100%;
+  }
+
+  .chip {
+    font-size: 11px;
+  }
+}

--- a/backend/apps/admin_ui/templates/base.html
+++ b/backend/apps/admin_ui/templates/base.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>{% block title %}Админка{% endblock %} · TG Bot Admin</title>
   <link rel="icon" href="/static/favicon.ico">
+  <link rel="stylesheet" href="/static/css/lists.css">
   <script>
     (function () {
       var storageKey = "tg-admin-theme";

--- a/backend/apps/admin_ui/templates/cities_list.html
+++ b/backend/apps/admin_ui/templates/cities_list.html
@@ -1,312 +1,161 @@
 {% extends "base.html" %}
+{% from "partials/list_toolbar.html" import list_toolbar %}
 {% block title %}Города{% endblock %}
 {% block content %}
+<section class="page">
+  <header class="page-header">
+    <div>
+      <h1 class="page-title">Города</h1>
+      <p class="page-description">Управляйте ответственными, планами и текстами сообщений для каждого города.</p>
+    </div>
+    <div class="page-actions">
+      <a class="btn btn-primary" href="/cities/new">+ Новый город</a>
+    </div>
+  </header>
 
-<div class="card glass grain city-toolbar">
-  <div class="toolbar-top">
-    <h3 class="toolbar-title">
-      Города
-      <span class="badge" id="total_count">{{ cities|length }}</span>
-    </h3>
-    <a class="btn" href="/cities/new">+ Новый город</a>
-  </div>
-  <div class="toolbar-search">
-    <label for="city_search" class="muted">Поиск</label>
-    <div class="search-input">
+  {% call list_toolbar(
+    form_id="city_filters",
+    method="get",
+    mass_actions=[{'label': 'Сбросить', 'type': 'button', 'variant': 'ghost', 'button_type': 'button', 'attrs': 'id="city_reset"'}],
+    chips=[
+      {'label': 'Всего', 'value': cities|length, 'tone': 'info', 'value_id': 'total_count'},
+      {'label': 'Найдено', 'value': (cities|length|string) ~ ' / ' ~ (cities|length|string), 'tone': 'success', 'value_id': 'found_badge'}
+    ]
+  ) %}
+    <div class="form-field form-field--wide">
+      <label for="city_search">Поиск</label>
       <input id="city_search" type="search" placeholder="Москва, Novosibirsk, Europe/Moscow…">
-      <button id="city_reset" class="btn btn-ghost" type="button" title="Сбросить фильтр">Сбросить</button>
     </div>
-    <span class="badge" id="found_badge" title="Найдено / всего">{{ cities|length }} / {{ cities|length }}</span>
-  </div>
-</div>
+  {% endcall %}
 
-{% if not cities %}
-  <div class="card glass grain" data-tilt style="padding:16px;">
-    <h4>Пусто</h4>
-    <p class="muted">Пока нет ни одного города. Нажмите «Новый город», чтобы добавить первый.</p>
-    <div style="margin-top:8px;">
-      <a class="btn" href="/cities/new">+ Новый город</a>
+  {% if not cities %}
+    <div class="card glass grain">
+      <h3 class="section-title">Пока пусто</h3>
+      <p class="page-description">Добавьте город, чтобы настроить сообщения и ответственных.</p>
+      <div class="page-actions">
+        <a class="btn btn-primary" href="/cities/new">+ Новый город</a>
+      </div>
     </div>
-  </div>
-{% else %}
-  <div class="city-list" id="cities_list">
-    {% for c in cities %}
-      {% set tz = c.tz or "Europe/Moscow" %}
-      {% set criteria = c.criteria|default('') %}
-      {% set experts = c.experts|default('') %}
-      {% set plan_week = c.plan_week|default('') %}
-      {% set plan_month = c.plan_month|default('') %}
-      {% set owner_id = owners.get(c.id) %}
-      {% set owner = rec_map.get(owner_id) if owner_id else None %}
-      <article class="city-card"
-               data-id="{{ c.id }}"
-               data-name="{{ c.name|lower }}"
-               data-tz="{{ tz|lower }}"
-               data-criteria="{{ criteria|e }}"
-               data-experts="{{ experts|e }}"
-               data-plan-week="{{ plan_week }}"
-               data-plan-month="{{ plan_month }}"
-               data-owner-id="{{ owner_id or '' }}">
-        <div class="city-card__header">
-          <div class="city-card__title">
-            <span class="city-name">{{ c.name }}</span>
-            {% if not c.tz %}
-              <span class="badge" title="Используется TZ по умолчанию">TZ: Europe/Moscow</span>
-            {% endif %}
-          </div>
-          <div class="city-card__meta">
-            <span class="city-tz">TZ: <code>{{ tz }}</code></span>
-            <span class="city-owner {% if not owner %}muted{% endif %}">
-              {% if owner %}
-                {{ owner.name }}
-              {% else %}
-                Не назначен
+  {% else %}
+    <div class="city-collection" id="cities_list">
+      {% for c in cities %}
+        {% set tz = c.tz or "Europe/Moscow" %}
+        {% set criteria = c.criteria|default('') %}
+        {% set experts = c.experts|default('') %}
+        {% set plan_week = c.plan_week|default('') %}
+        {% set plan_month = c.plan_month|default('') %}
+        {% set owner_id = owners.get(c.id) %}
+        {% set owner = rec_map.get(owner_id) if owner_id else None %}
+        <article class="city-card"
+                 data-id="{{ c.id }}"
+                 data-name="{{ c.name|lower }}"
+                 data-tz="{{ tz|lower }}"
+                 data-criteria="{{ criteria|e }}"
+                 data-experts="{{ experts|e }}"
+                 data-plan-week="{{ plan_week }}"
+                 data-plan-month="{{ plan_month }}"
+                 data-owner-id="{{ owner_id or '' }}">
+          <div class="city-card__header">
+            <div class="city-card__title">
+              <span class="city-name">{{ c.name }}</span>
+              {% if not c.tz %}
+                <span class="badge" title="Используется TZ по умолчанию">TZ: Europe/Moscow</span>
               {% endif %}
-            </span>
-            <span class="badge plan-badge">
-              {% if plan_week or plan_month %}
-                Нед: {{ plan_week or '—' }} · Мес: {{ plan_month or '—' }}
-              {% else %}
-                Параметры не заданы
-              {% endif %}
-            </span>
+            </div>
+            <div class="city-card__meta">
+              <span class="city-tz">TZ: <code>{{ tz }}</code></span>
+              <span class="city-owner {% if not owner %}muted{% endif %}">
+                {% if owner %}
+                  {{ owner.name }}
+                {% else %}
+                  Не назначен
+                {% endif %}
+              </span>
+              <span class="badge plan-badge">
+                {% if plan_week or plan_month %}
+                  Нед: {{ plan_week or '—' }} · Мес: {{ plan_month or '—' }}
+                {% else %}
+                  Параметры не заданы
+                {% endif %}
+              </span>
+            </div>
+            <div class="city-card__actions">
+              <button class="btn btn-soft btn-edit" type="button" title="Настроить город">Настроить</button>
+            </div>
           </div>
-          <div class="city-card__actions">
-            <button class="btn btn-edit" type="button" title="Настроить город">Настроить</button>
-          </div>
-        </div>
-        <div class="city-details" hidden>
-          <form class="city-form" data-id="{{ c.id }}">
-            <div class="field">
-              <label for="owner_{{ c.id }}">Ответственный рекрутёр</label>
-              <select id="owner_{{ c.id }}" name="responsible_id" class="responsible-select">
-                <option value="">— Не назначен —</option>
-                {% for r in recruiters %}
-                  <option value="{{ r.id }}" {% if owner_id == r.id %}selected{% endif %}>{{ r.name }}</option>
-                {% endfor %}
-              </select>
-            </div>
+          <div class="city-card__details" hidden>
+            <form class="city-form" data-id="{{ c.id }}">
+              <div class="form-field">
+                <label for="owner_{{ c.id }}">Ответственный рекрутёр</label>
+                <select id="owner_{{ c.id }}" name="responsible_id" class="responsible-select">
+                  <option value="">— Не назначен —</option>
+                  {% for r in recruiters %}
+                    <option value="{{ r.id }}" {% if owner_id == r.id %}selected{% endif %}>{{ r.name }}</option>
+                  {% endfor %}
+                </select>
+              </div>
 
-            <div class="form-grid">
-              <div class="field">
-                <label for="crit_{{ c.id }}">Критерии отбора</label>
-                <textarea id="crit_{{ c.id }}" name="criteria" rows="4" placeholder="Опыт продаж от 6 мес, грамотная речь, готовность к гибридному формату…">{{ criteria }}</textarea>
-              </div>
-              <div class="field">
-                <label for="exp_{{ c.id }}">Ресурсы экспертов</label>
-                <textarea id="exp_{{ c.id }}" name="experts" rows="4" placeholder="Эксперт A: 10 ч/нед; Эксперт B: 6 ч/нед; Каналы: внутренний реферальный, ярмарки вакансий…">{{ experts }}</textarea>
-              </div>
-            </div>
-
-            <div class="form-grid">
-              <div class="field">
-                <label for="pw_{{ c.id }}">План набора (неделя)</label>
-                <input id="pw_{{ c.id }}" name="plan_week" type="number" min="0" step="1" value="{{ plan_week }}" placeholder="Например, 12">
-              </div>
-              <div class="field">
-                <label for="pm_{{ c.id }}">План набора (месяц)</label>
-                <input id="pm_{{ c.id }}" name="plan_month" type="number" min="0" step="1" value="{{ plan_month }}" placeholder="Например, 48">
-              </div>
-            </div>
-
-            <div class="stage-block">
-              <h4>Шаги и шаблоны сообщений</h4>
-              <p class="muted">Настройте тексты, которые бот отправит кандидату на каждом этапе. Оставьте поле пустым, чтобы использовать текст по умолчанию.</p>
-              {% set stages = city_stages.get(c.id, []) %}
-              {% for stage in stages %}
-                <div class="field stage-field" data-stage="{{ stage.key }}">
-                  <label for="stage_{{ stage.key }}_{{ c.id }}">{{ stage.title }}</label>
-                  <textarea
-                    id="stage_{{ stage.key }}_{{ c.id }}"
-                    name="stage__{{ stage.key }}"
-                    data-stage="{{ stage.key }}"
-                    data-default="{{ stage.default|e }}"
-                    rows="6"
-                    placeholder="{{ stage.default|e }}">{{ stage.value }}</textarea>
-                  <div class="stage-controls">
-                    <button type="button" class="btn mini ghost stage-default-btn" data-stage="{{ stage.key }}">Вставить текст по умолчанию</button>
-                    <span class="muted">{{ stage.description }}</span>
-                  </div>
+              <div class="form-grid">
+                <div class="form-field">
+                  <label for="crit_{{ c.id }}">Критерии отбора</label>
+                  <textarea id="crit_{{ c.id }}" name="criteria" rows="4" placeholder="Опыт продаж от 6 мес, грамотная речь, готовность к гибридному формату…">{{ criteria }}</textarea>
                 </div>
-              {% endfor %}
-              <p class="muted">
-                {% raw %}
-                Доступные переменные: <code>{{candidate_fio}}</code>, <code>{{city_name}}</code>, <code>{{interview_dt_hint}}</code>, <code>{{slot_date_local}}</code>, <code>{{slot_time_local}}</code>, <code>{{slot_datetime_local}}</code>, <code>{{recruiter_name}}</code>, <code>{{address}}</code>.
-                {% endraw %}
-              </p>
-            </div>
+                <div class="form-field">
+                  <label for="exp_{{ c.id }}">Ресурсы экспертов</label>
+                  <textarea id="exp_{{ c.id }}" name="experts" rows="4" placeholder="Эксперт A: 10 ч/нед; Эксперт B: 6 ч/нед; Каналы: внутренний реферальный, ярмарки вакансий…">{{ experts }}</textarea>
+                </div>
+              </div>
 
-            <div class="form-actions">
-              <button type="submit" class="btn btn-save">Сохранить</button>
-              <button type="button" class="btn btn-cancel">Отмена</button>
-              <span class="badge muted save-status" style="display:none;">Сохранено</span>
-            </div>
-          </form>
-        </div>
-      </article>
-    {% endfor %}
-  </div>
-{% endif %}
+              <div class="form-grid">
+                <div class="form-field">
+                  <label for="pw_{{ c.id }}">План набора (неделя)</label>
+                  <input id="pw_{{ c.id }}" name="plan_week" type="number" min="0" step="1" value="{{ plan_week }}" placeholder="Например, 12">
+                </div>
+                <div class="form-field">
+                  <label for="pm_{{ c.id }}">План набора (месяц)</label>
+                  <input id="pm_{{ c.id }}" name="plan_month" type="number" min="0" step="1" value="{{ plan_month }}" placeholder="Например, 48">
+                </div>
+              </div>
 
-<style>
-  .city-toolbar {
-    margin: 8px 0 16px;
-    padding: 16px;
-    display: flex;
-    flex-direction: column;
-    gap: 16px;
-  }
-  .toolbar-top {
-    display: flex;
-    gap: 12px;
-    align-items: center;
-    justify-content: space-between;
-    flex-wrap: wrap;
-  }
-  .toolbar-title {
-    margin: 0;
-    display: flex;
-    align-items: center;
-    gap: 8px;
-  }
-  .toolbar-search {
-    display: grid;
-    gap: 8px;
-  }
-  .toolbar-search .muted {
-    font-size: 0.85rem;
-  }
-  .search-input {
-    display: flex;
-    gap: 8px;
-    flex-wrap: wrap;
-  }
-  .btn-ghost {
-    background: rgba(255,255,255,.04);
-    border: 1px solid rgba(255,255,255,.12);
-  }
-  .search-input input[type="search"] {
-    flex: 1 1 220px;
-    min-width: 160px;
-  }
-  .city-list {
-    display: flex;
-    flex-direction: column;
-    gap: 12px;
-  }
-  .city-card {
-    border-radius: var(--radius-lg);
-    background: linear-gradient(180deg, rgba(255,255,255,.05), rgba(255,255,255,.02));
-    border: 1px solid var(--glass-stroke);
-    padding: 16px;
-    display: flex;
-    flex-direction: column;
-    gap: 12px;
-  }
-  .city-card__header {
-    display: grid;
-    grid-template-columns: minmax(0, 1fr);
-    gap: 12px;
-    align-items: center;
-  }
-  .city-card__title {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    flex-wrap: wrap;
-  }
-  .city-card__title .city-name {
-    font-weight: 600;
-    font-size: 1.05rem;
-  }
-  .city-card__meta {
-    display: flex;
-    gap: 12px;
-    align-items: center;
-    flex-wrap: wrap;
-    color: var(--muted);
-    font-size: 0.9rem;
-  }
-  .city-card__meta code {
-    font-size: 0.9rem;
-  }
-  .city-card__actions {
-    display: flex;
-    gap: 8px;
-    justify-content: flex-start;
-  }
-  @media (min-width: 760px) {
-    .city-card__header {
-      grid-template-columns: minmax(0, 1.4fr) minmax(0, 1fr) auto;
-      align-items: center;
-    }
-    .city-card__actions {
-      justify-content: flex-end;
-    }
-  }
-  .city-details {
-    border-top: 1px solid var(--glass-stroke);
-    padding-top: 12px;
-    display: none;
-    flex-direction: column;
-    gap: 16px;
-  }
-  .city-card.open .city-details {
-    display: flex;
-  }
-  .field label {
-    display: block;
-    margin-bottom: 6px;
-    color: var(--muted);
-    font-weight: 600;
-  }
-  .field textarea {
-    width: 100%;
-    min-height: 92px;
-    resize: vertical;
-  }
-  .form-grid {
-    display: grid;
-    gap: 12px;
-  }
-  @media (min-width: 860px) {
-    .form-grid {
-      grid-template-columns: repeat(2, minmax(0, 1fr));
-    }
-  }
-  .stage-block {
-    display: flex;
-    flex-direction: column;
-    gap: 16px;
-  }
-  .stage-block h4 {
-    margin: 0;
-  }
-  .stage-field textarea {
-    min-height: 140px;
-  }
-  .stage-controls {
-    display: flex;
-    gap: 8px;
-    align-items: center;
-    flex-wrap: wrap;
-    margin-top: 6px;
-  }
-  .form-actions {
-    display: flex;
-    gap: 8px;
-    flex-wrap: wrap;
-    align-items: center;
-  }
-  .save-status.ok {
-    color: var(--ok);
-    display: inline-block !important;
-  }
-  .save-status.err {
-    color: var(--bad);
-    display: inline-block !important;
-  }
-</style>
+              <div class="stage-block">
+                <h4>Шаги и шаблоны сообщений</h4>
+                <p class="muted">Настройте тексты, которые бот отправит кандидату на каждом этапе. Оставьте поле пустым, чтобы использовать текст по умолчанию.</p>
+                {% set stages = city_stages.get(c.id, []) %}
+                {% for stage in stages %}
+                  <div class="stage-field" data-stage="{{ stage.key }}">
+                    <label for="stage_{{ stage.key }}_{{ c.id }}">{{ stage.title }}</label>
+                    <textarea
+                      id="stage_{{ stage.key }}_{{ c.id }}"
+                      name="stage__{{ stage.key }}"
+                      data-stage="{{ stage.key }}"
+                      data-default="{{ stage.default|e }}"
+                      rows="6"
+                      placeholder="{{ stage.default|e }}">{{ stage.value }}</textarea>
+                    <div class="stage-controls">
+                      <button type="button" class="btn btn-ghost btn--small stage-default-btn" data-stage="{{ stage.key }}">Вставить текст по умолчанию</button>
+                      <span class="muted">{{ stage.description }}</span>
+                    </div>
+                  </div>
+                {% endfor %}
+                <p class="muted">
+                  {% raw %}
+                  Доступные переменные: <code>{{candidate_fio}}</code>, <code>{{city_name}}</code>, <code>{{interview_dt_hint}}</code>, <code>{{slot_date_local}}</code>, <code>{{slot_time_local}}</code>, <code>{{slot_datetime_local}}</code>, <code>{{recruiter_name}}</code>, <code>{{address}}</code>.
+                  {% endraw %}
+                </p>
+              </div>
+
+              <div class="form-actions">
+                <button type="submit" class="btn btn-primary">Сохранить</button>
+                <button type="button" class="btn btn-ghost btn-cancel">Отмена</button>
+                <span class="badge muted save-status">Сохранено</span>
+              </div>
+            </form>
+          </div>
+        </article>
+      {% endfor %}
+    </div>
+  {% endif %}
+</section>
 
 <script>
 (function(){
@@ -328,7 +177,7 @@
   function closeAll(){
     cards.forEach(card => {
       card.classList.remove('open');
-      const details = card.querySelector('.city-details');
+      const details = card.querySelector('.city-card__details');
       if (details) details.hidden = true;
     });
   }
@@ -346,7 +195,7 @@
       } else {
         card.style.display = 'none';
         card.classList.remove('open');
-        const details = card.querySelector('.city-details');
+        const details = card.querySelector('.city-card__details');
         if (details) details.hidden = true;
       }
     });
@@ -381,7 +230,7 @@
       const card = cancelBtn.closest('.city-card');
       if (card) {
         card.classList.remove('open');
-        const details = card.querySelector('.city-details');
+        const details = card.querySelector('.city-card__details');
         if (details) details.hidden = true;
       }
       return;
@@ -391,7 +240,7 @@
     if (!btn) return;
     const card = btn.closest('.city-card');
     if (!card) return;
-    const details = card.querySelector('.city-details');
+    const details = card.querySelector('.city-card__details');
     if (!details) return;
 
     const isOpen = card.classList.contains('open');
@@ -401,14 +250,16 @@
 
     const form = details.querySelector('form.city-form');
     if (form) {
-      form.querySelector('[name="criteria"]').value = card.dataset.criteria || '';
-      form.querySelector('[name="experts"]').value = card.dataset.experts || '';
-      form.querySelector('[name="plan_week"]').value = card.dataset.planWeek || '';
-      form.querySelector('[name="plan_month"]').value = card.dataset.planMonth || '';
+      const criteriaField = form.querySelector('[name="criteria"]');
+      const expertsField = form.querySelector('[name="experts"]');
+      const planWeekField = form.querySelector('[name="plan_week"]');
+      const planMonthField = form.querySelector('[name="plan_month"]');
+      if (criteriaField) criteriaField.value = card.dataset.criteria || '';
+      if (expertsField) expertsField.value = card.dataset.experts || '';
+      if (planWeekField) planWeekField.value = card.dataset.planWeek || '';
+      if (planMonthField) planMonthField.value = card.dataset.planMonth || '';
       const ownerSelect = form.querySelector('[name="responsible_id"]');
-      if (ownerSelect) {
-        ownerSelect.value = card.dataset.ownerId || '';
-      }
+      if (ownerSelect) ownerSelect.value = card.dataset.ownerId || '';
     }
 
     card.classList.add('open');
@@ -499,7 +350,7 @@
       }
 
       card.classList.remove('open');
-      const details = card.querySelector('.city-details');
+      const details = card.querySelector('.city-card__details');
       if (details) details.hidden = true;
 
       setTimeout(()=>{

--- a/backend/apps/admin_ui/templates/partials/list_toolbar.html
+++ b/backend/apps/admin_ui/templates/partials/list_toolbar.html
@@ -1,0 +1,69 @@
+{% macro toolbar_action(action) %}
+  {% set variant = action.variant|default('ghost') %}
+  {% set type = action.type|default('link') %}
+  {% set label = action.label|default('') %}
+  {% set href = action.href|default('#') %}
+  {% set button_type = action.button_type|default('button') %}
+  {% set attrs = action.attrs|default('') %}
+  {% set icon = action.icon %}
+  {% set disabled = action.disabled|default(false) %}
+  {% if type == 'button' %}
+    <button type="{{ button_type }}" class="btn btn-{{ variant }}" {{ attrs|safe }}{% if disabled %} disabled{% endif %}>
+      {% if icon %}<span class="btn__icon">{{ icon|safe }}</span>{% endif %}
+      {{ label }}
+    </button>
+  {% else %}
+    <a href="{{ href }}" class="btn btn-{{ variant }}" {{ attrs|safe }}{% if disabled %} aria-disabled="true"{% endif %}>
+      {% if icon %}<span class="btn__icon">{{ icon|safe }}</span>{% endif %}
+      {{ label }}
+    </a>
+  {% endif %}
+{% endmacro %}
+
+{% macro toolbar_chip(chip) %}
+  {% set tone = chip.tone|default('info') %}
+  {% set label = chip.label|default('') %}
+  {% set value = chip.value %}
+  {% set icon = chip.icon %}
+  {% set attrs = chip.attrs|default('') %}
+  {% set value_id = chip.value_id %}
+  <span class="chip chip--{{ tone }}" {{ attrs|safe }}>
+    {% if icon %}<span class="chip__icon">{{ icon|safe }}</span>{% endif %}
+    <span class="chip__label">{{ label }}</span>
+    {% if value is not none %}<span class="chip__value"{% if value_id %} id="{{ value_id }}"{% endif %}>{{ value }}</span>{% endif %}
+  </span>
+{% endmacro %}
+
+{% macro list_toolbar(form_id=None, form_action='#', method='get', actions=None, chips=None, mass_actions=None, sticky=False, form_attrs='') %}
+  {% set actions = actions or [] %}
+  {% set chips = chips or [] %}
+  {% set mass_actions = mass_actions or [] %}
+  <section class="list-toolbar{% if sticky %} list-toolbar--sticky{% endif %}">
+    <form{% if form_id %} id="{{ form_id }}"{% endif %} class="list-toolbar__form" action="{{ form_action }}" method="{{ method }}" {{ form_attrs|safe }}>
+      <div class="list-toolbar__filters">
+        {{ caller() }}
+      </div>
+      {% if mass_actions %}
+        <div class="list-toolbar__mass">
+          {% for action in mass_actions %}
+            {{ toolbar_action(action) }}
+          {% endfor %}
+        </div>
+      {% endif %}
+      {% if actions %}
+        <div class="list-toolbar__actions">
+          {% for action in actions %}
+            {{ toolbar_action(action) }}
+          {% endfor %}
+        </div>
+      {% endif %}
+    </form>
+    {% if chips %}
+      <div class="list-toolbar__chips">
+        {% for chip in chips %}
+          {{ toolbar_chip(chip) }}
+        {% endfor %}
+      </div>
+    {% endif %}
+  </section>
+{% endmacro %}

--- a/backend/apps/admin_ui/templates/questions_list.html
+++ b/backend/apps/admin_ui/templates/questions_list.html
@@ -3,79 +3,84 @@
 {% block title %}Вопросы{% endblock %}
 
 {% block content %}
-<section class="glass" style="padding:24px; margin-bottom:20px;">
-  <h1 style="margin-top:0;">База вопросов</h1>
-  <p class="muted" style="max-width:720px;">
-    Здесь собраны вопросы для всех тестов. Вы можете открыть вопрос и изменить его текст,
-    варианты ответов или структуру JSON. Изменения вступят в силу после сохранения.
-  </p>
-</section>
+<section class="page">
+  <header class="page-header">
+    <div>
+      <h1 class="page-title">База вопросов</h1>
+      <p class="page-description">
+        Здесь собраны вопросы для всех тестов. Вы можете открыть вопрос и изменить его текст, варианты ответов или структуру JSON.
+      </p>
+    </div>
+  </header>
 
-{% if tests %}
-  {% for test in tests %}
-    <section class="glass" style="padding:18px; margin-bottom:20px;" data-tilt>
-      <header style="display:flex; align-items:center; gap:12px; margin-bottom:14px;">
-        <h2 style="margin:0; font-size:20px;">{{ test.title }}</h2>
-        <span class="badge">{{ test.test_id }}</span>
-        <span class="muted" style="margin-left:auto;">{{ test.questions|length }} вопросов</span>
-      </header>
-      <div style="overflow-x:auto;">
-        <table>
-          <thead>
-            <tr>
-              <th style="width:80px;">№</th>
-              <th>Вопрос</th>
-              <th style="width:140px;">Тип</th>
-              <th style="width:160px;">Последнее изменение</th>
-              <th style="width:120px;">Статус</th>
-              <th style="width:120px; text-align:right;">Действия</th>
-            </tr>
-          </thead>
-          <tbody>
-          {% for item in test.questions %}
-            <tr>
-              <td>{{ item.index }}</td>
-              <td>
-                <div style="font-weight:600;">{{ item.title }}</div>
-                <div class="muted" style="font-size:12px;">{{ item.prompt }}</div>
-                {% if item.options_count %}
-                  <div class="muted" style="font-size:12px; margin-top:4px;">
-                    Вариантов: {{ item.options_count }}{% if item.correct_label %}, верный: {{ item.correct_label }}{% endif %}
-                  </div>
-                {% endif %}
-              </td>
-              <td>
-                {% if item.kind == 'choice' %}
-                  <span class="badge" style="display:inline-block;">Варианты</span>
-                {% else %}
-                  <span class="badge" style="display:inline-block;">Свободный ответ</span>
-                {% endif %}
-              </td>
-              <td>{% if item.updated_at %}{{ fmt_utc(item.updated_at) }} UTC{% else %}—{% endif %}</td>
-              <td>
-                {% if item.is_active %}
-                  <span class="badge" style="color:var(--ok); border-color:rgba(35,209,139,.35);">Активен</span>
-                {% else %}
-                  <span class="badge" style="color:var(--muted);">Скрыт</span>
-                {% endif %}
-              </td>
-              <td style="text-align:right;">
-                <a class="btn" href="/questions/{{ item.id }}/edit">Редактировать</a>
-              </td>
-            </tr>
-          {% else %}
-            <tr>
-              <td colspan="6" style="text-align:center; padding:20px;" class="muted">Пока нет вопросов.</td>
-            </tr>
-          {% endfor %}
-          </tbody>
-        </table>
-      </div>
+  {% if tests %}
+    {% for test in tests %}
+      <section class="test-section" data-tilt>
+        <header class="test-section__header">
+          <h2 class="card-title">{{ test.title }}</h2>
+          <span class="badge">{{ test.test_id }}</span>
+          <span class="test-section__meta">{{ test.questions|length }} вопросов</span>
+        </header>
+        <div class="list-table-wrapper">
+          <table class="list-table list-table--responsive">
+            <thead>
+              <tr>
+                <th>№</th>
+                <th>Вопрос</th>
+                <th>Тип</th>
+                <th>Последнее изменение</th>
+                <th>Статус</th>
+                <th class="cell-actions">Действия</th>
+              </tr>
+            </thead>
+            <tbody>
+            {% for item in test.questions %}
+              <tr>
+                <td data-label="№">{{ item.index }}</td>
+                <td data-label="Вопрос">
+                  <div class="question-title">{{ item.title }}</div>
+                  <div class="question-meta">{{ item.prompt }}</div>
+                  {% if item.options_count %}
+                    <div class="question-meta--small">
+                      Вариантов: {{ item.options_count }}{% if item.correct_label %}, верный: {{ item.correct_label }}{% endif %}
+                    </div>
+                  {% endif %}
+                </td>
+                <td data-label="Тип">
+                  {% if item.kind == 'choice' %}
+                    <span class="badge">Варианты</span>
+                  {% else %}
+                    <span class="badge">Свободный ответ</span>
+                  {% endif %}
+                </td>
+                <td data-label="Последнее изменение">{% if item.updated_at %}{{ fmt_utc(item.updated_at) }} UTC{% else %}—{% endif %}</td>
+                <td data-label="Статус">
+                  {% if item.is_active %}
+                    <span class="status-badge" data-tone="success">Активен</span>
+                  {% else %}
+                    <span class="status-badge" data-tone="danger">Скрыт</span>
+                  {% endif %}
+                </td>
+                <td class="cell-actions" data-label="">
+                  <a class="btn btn-soft" href="/questions/{{ item.id }}/edit">Редактировать</a>
+                </td>
+              </tr>
+            {% else %}
+              <tr>
+                <td colspan="6" data-label="">
+                  <div class="muted table-empty">Пока нет вопросов.</div>
+                </td>
+              </tr>
+            {% endfor %}
+            </tbody>
+          </table>
+        </div>
+      </section>
+    {% endfor %}
+  {% else %}
+    <section class="test-section">
+      <p class="page-description">Вопросы ещё не добавлены.</p>
     </section>
-  {% endfor %}
-{% else %}
-  <section class="glass" style="padding:24px;">
-    <p class="muted" style="margin:0;">Вопросы ещё не добавлены.</p>
-  </section>
-{% endif %}
+  {% endif %}
+</section>
 {% endblock %}

--- a/backend/apps/admin_ui/templates/recruiters_list.html
+++ b/backend/apps/admin_ui/templates/recruiters_list.html
@@ -1,69 +1,32 @@
 {% extends "base.html" %}
+{% from "partials/list_toolbar.html" import list_toolbar %}
 {% block title %}Рекрутёры{% endblock %}
 {% block content %}
-<style>
-  .page { display:flex; flex-direction:column; gap:24px; }
-  .page-header { display:flex; justify-content:space-between; align-items:flex-start; gap:16px; flex-wrap:wrap; }
-  .page-header h1 { margin:0; font-size:28px; font-weight:700; }
-  .page-header p { margin:6px 0 0; color:var(--muted); max-width:420px; }
-  .page-header .actions { display:flex; gap:10px; flex-wrap:wrap; }
-
-  .filters { display:flex; gap:12px; flex-wrap:wrap; padding:16px; border-radius:var(--radius-lg); border:1px solid var(--glass-stroke); background:linear-gradient(180deg, rgba(255,255,255,.08), rgba(255,255,255,.02)); box-shadow:var(--shadow-1); }
-  .filters .field { display:flex; flex-direction:column; gap:6px; min-width:220px; flex:1 1 200px; }
-  .filters label { font-weight:600; color:var(--muted); font-size:13px; }
-  .filters input,
-  .filters select { padding:10px 12px; border-radius:var(--radius-md); border:1px solid var(--field-border); background:var(--field-bg); color:inherit; box-shadow:var(--field-shadow); }
-  .filters button { align-self:flex-end; margin-left:auto; }
-
-  .grid { display:grid; gap:16px; grid-template-columns:repeat(auto-fit, minmax(280px, 1fr)); }
-  .card-rec { display:flex; flex-direction:column; gap:12px; padding:18px; border-radius:var(--radius-lg); border:1px solid var(--glass-stroke); background:linear-gradient(180deg, rgba(255,255,255,.07), rgba(255,255,255,.015)); box-shadow:var(--shadow-2); min-height:240px; }
-  .card-rec header { display:flex; justify-content:space-between; gap:12px; align-items:flex-start; }
-  .card-rec h2 { margin:0; font-size:18px; }
-  .card-rec .meta { display:flex; flex-wrap:wrap; gap:6px; font-size:12px; color:var(--muted); }
-  .card-rec .meta span { display:inline-flex; gap:4px; align-items:center; padding:4px 8px; border-radius:999px; background:rgba(255,255,255,.06); border:1px solid rgba(255,255,255,.1); }
-  .card-rec .chips { display:flex; flex-wrap:wrap; gap:6px; }
-  .card-rec .chips span { padding:4px 8px; border-radius:999px; background:rgba(255,255,255,.05); font-size:12px; }
-  .card-rec .chips .free { color:var(--ok); }
-  .card-rec .chips .pending { color:var(--warn); }
-  .card-rec .chips .booked { color:var(--accent); }
-  .card-rec .cities { display:flex; flex-wrap:wrap; gap:6px; }
-  .card-rec .cities span { padding:4px 10px; border-radius:999px; background:rgba(255,255,255,.05); border:1px solid rgba(255,255,255,.08); font-size:12px; }
-  .card-rec footer { margin-top:auto; display:flex; gap:8px; flex-wrap:wrap; }
-  .card-rec footer .btn { flex:1 1 auto; text-align:center; }
-  .status-pill { display:inline-flex; align-items:center; gap:6px; padding:6px 12px; border-radius:999px; font-weight:600; }
-  .status-on { background:rgba(46,204,113,.12); color:#2ecc71; border:1px solid rgba(46,204,113,.25); }
-  .status-off { background:rgba(255,107,107,.12); color:#ff6b6b; border:1px solid rgba(255,107,107,.18); }
-
-  .btn { padding:10px 16px; border-radius:var(--radius-md); border:1px solid rgba(255,255,255,0.12); background:var(--btn-bg); color:inherit; cursor:pointer; text-decoration:none; display:inline-flex; justify-content:center; align-items:center; gap:6px; }
-  .btn:hover { background:var(--btn-bg-hover); }
-  .btn-primary { background:linear-gradient(135deg,#579bff,#8d5bff); border:none; color:#fff; box-shadow:var(--shadow-2); }
-  .btn-ghost { background:rgba(255,255,255,.04); border:1px solid rgba(255,255,255,.12); }
-  .empty { padding:32px; border-radius:var(--radius-lg); border:1px dashed rgba(255,255,255,.2); text-align:center; color:var(--muted); }
-
-  @media (max-width: 640px) {
-    .page-header { flex-direction:column; align-items:flex-start; }
-    .page-header .actions { width:100%; justify-content:flex-start; }
-    .card-rec footer .btn { flex:1 1 100%; }
-  }
-</style>
-
 <section class="page">
-  <div class="page-header">
+  <header class="page-header">
     <div>
-      <h1>Рекрутёры</h1>
-      <p>Следите за нагрузкой, ближайшими слотами и ответственными городами каждого рекрутёра.</p>
+      <h1 class="page-title">Рекрутёры</h1>
+      <p class="page-description">
+        Следите за нагрузкой, ближайшими слотами и ответственными городами каждого рекрутёра.
+      </p>
     </div>
-    <div class="actions">
+    <div class="page-actions">
       <a class="btn btn-primary" href="/recruiters/new">Добавить рекрутёра</a>
     </div>
-  </div>
+  </header>
 
-  <div class="filters">
-    <div class="field">
+  {% call list_toolbar(form_id="recruiter_filters", method="get", mass_actions=[{
+    'label': 'Сбросить',
+    'type': 'button',
+    'variant': 'ghost',
+    'button_type': 'button',
+    'attrs': 'id="flt_reset"'
+  }]) %}
+    <div class="form-field form-field--wide">
       <label for="flt_query">Поиск</label>
-      <input id="flt_query" type="text" placeholder="Имя, город или chat_id">
+      <input id="flt_query" type="search" placeholder="Имя, город или chat_id">
     </div>
-    <div class="field" style="max-width:220px;">
+    <div class="form-field form-field--narrow">
       <label for="flt_state">Статус</label>
       <select id="flt_state">
         <option value="">Все</option>
@@ -71,32 +34,32 @@
         <option value="off">Отключённые</option>
       </select>
     </div>
-    <button class="btn btn-ghost" type="button" id="flt_reset">Сбросить</button>
-  </div>
+  {% endcall %}
 
   {% if not recruiter_rows %}
-    <div class="empty">
-      Записи отсутствуют. Создайте первого рекрутёра, чтобы начать работу.
-      <div style="margin-top:12px;">
+    <div class="card glass grain">
+      <h3 class="section-title">Пока пусто</h3>
+      <p class="page-description">Записи отсутствуют. Создайте первого рекрутёра, чтобы начать работу.</p>
+      <div class="page-actions">
         <a class="btn btn-primary" href="/recruiters/new">Добавить рекрутёра</a>
       </div>
     </div>
   {% else %}
-    <div id="recs_grid" class="grid">
+    <div id="recs_grid" class="card-grid">
       {% for item in recruiter_rows %}
         {% set r = item.rec %}
         {% set stats = item.stats %}
         {% set active = r.active if r.active is not none else False %}
-        <article class="card-rec"
+        <article class="recruiter-card"
                  data-name="{{ (r.name or '')|lower }}"
                  data-tz="{{ (r.tz or 'Europe/Moscow')|lower }}"
                  data-chat="{{ r.tg_chat_id or '' }}"
                  data-cities="{{ item.cities_text }}"
                  data-active="{{ 'on' if active else 'off' }}">
-          <header>
+          <header class="recruiter-card__header">
             <div>
-              <h2>{{ r.name }}</h2>
-              <div class="meta">
+              <h2 class="recruiter-card__name">{{ r.name }}</h2>
+              <div class="meta-list">
                 <span>#{{ r.id }}</span>
                 <span title="Часовой пояс">TZ: {{ r.tz or 'Europe/Moscow' }}</span>
                 {% if r.tg_chat_id %}
@@ -104,26 +67,27 @@
                 {% endif %}
               </div>
             </div>
-            <span class="status-pill {{ 'status-on' if active else 'status-off' }}">
+            <span class="status-pill" data-state="{{ 'on' if active else 'off' }}">
               {{ 'Активен' if active else 'Отключен' }}
             </span>
           </header>
 
-          <div>
-            <div class="chips">
-              <span class="free">Свободно {{ stats.free }}</span>
-              <span class="pending">Ожидают {{ stats.pending }}</span>
-              <span class="booked">Занято {{ stats.booked }}</span>
-              <span>Всего {{ stats.total }}</span>
+          <div class="section-block">
+            <h3 class="section-title">Нагрузка</h3>
+            <div class="chip-row">
+              <span class="chip chip--success">Свободно <span class="chip__value">{{ stats.free }}</span></span>
+              <span class="chip chip--warning">Ожидают <span class="chip__value">{{ stats.pending }}</span></span>
+              <span class="chip chip--info">Занято <span class="chip__value">{{ stats.booked }}</span></span>
+              <span class="chip">Всего <span class="chip__value">{{ stats.total }}</span></span>
             </div>
           </div>
 
-          <div>
-            <strong style="font-size:13px;">Города</strong>
-            <div class="cities">
+          <div class="section-block">
+            <h3 class="section-title">Города</h3>
+            <div class="badge-row">
               {% if item.cities %}
                 {% for cname, ctz in item.cities %}
-                  <span title="{{ ctz }}">{{ cname }}</span>
+                  <span class="badge" title="{{ ctz }}">{{ cname }}</span>
                 {% endfor %}
               {% else %}
                 <span class="muted">не назначены</span>
@@ -131,10 +95,10 @@
             </div>
           </div>
 
-          <div>
-            <strong style="font-size:13px;">Ближайший свободный слот</strong><br>
+          <div class="section-block">
+            <h3 class="section-title">Ближайший свободный слот</h3>
             {% if item.next_free_local %}
-              <span class="badge" style="margin-top:4px; display:inline-block;">
+              <span class="badge">
                 {{ item.next_free_local }}{% if not item.next_is_future %} · истёк{% endif %}
               </span>
             {% else %}
@@ -142,13 +106,13 @@
             {% endif %}
           </div>
 
-          <footer>
-            <button class="btn btn-ghost" type="button" data-copy="{{ r.tg_chat_id or '' }}" {% if not r.tg_chat_id %}disabled{% endif %}>
+          <footer class="recruiter-card__footer">
+            <button class="btn btn-ghost btn--grow" type="button" data-copy="{{ r.tg_chat_id or '' }}" {% if not r.tg_chat_id %}disabled{% endif %}>
               Скопировать chat_id
             </button>
-            <a class="btn btn-ghost" href="/recruiters/{{ r.id }}/edit">Редактировать</a>
-            <form method="post" action="/recruiters/{{ r.id }}/delete" onsubmit="return confirm('Удалить рекрутёра {{ r.name }}?');" style="margin:0;">
-              <button class="btn btn-ghost" type="submit">Удалить</button>
+            <a class="btn btn-soft btn--grow" href="/recruiters/{{ r.id }}/edit">Редактировать</a>
+            <form class="inline-form" method="post" action="/recruiters/{{ r.id }}/delete" onsubmit="return confirm('Удалить рекрутёра {{ r.name }}?');">
+              <button class="btn btn-danger btn--grow" type="submit">Удалить</button>
             </form>
           </footer>
         </article>
@@ -164,7 +128,7 @@
   const q = $('#flt_query');
   const state = $('#flt_state');
   const reset = $('#flt_reset');
-  const cards = $$('#recs_grid .card-rec');
+  const cards = $$('#recs_grid .recruiter-card');
   const norm = v => (v || '').toString().toLowerCase().trim();
 
   const apply = () => {
@@ -190,7 +154,7 @@
   });
   apply();
 
-  $$('.card-rec button[data-copy]').forEach(btn => {
+  $$('#recs_grid .recruiter-card button[data-copy]').forEach(btn => {
     btn.addEventListener('click', async () => {
       const value = btn.getAttribute('data-copy');
       if (!value) return;

--- a/backend/apps/admin_ui/templates/slots_list.html
+++ b/backend/apps/admin_ui/templates/slots_list.html
@@ -1,44 +1,34 @@
 {% extends "base.html" %}
+{% from "partials/list_toolbar.html" import list_toolbar %}
 {% block title %}Слоты{% endblock %}
 {% block content %}
+<section class="page">
+  <header class="page-header">
+    <div>
+      <h1 class="page-title">Слоты</h1>
+      <p class="page-description">
+        Управляйте слотами интервью, фильтруйте по рекрутёрам и статусу и следите за балансом загрузки.
+      </p>
+    </div>
+    <div class="page-actions">
+      <a class="btn btn-primary" href="/slots/new">+ Новый слот</a>
+    </div>
+  </header>
 
-<style>
-  /* sticky tools */
-  .toolbar{position:sticky;top:8px;z-index:5}
-  .chips{display:flex;gap:6px;flex-wrap:wrap}
-  .chip{font-size:12px;padding:4px 8px;border-radius:999px;border:1px solid var(--glass-stroke);background:rgba(255,255,255,.06)}
-  .chip-free{border-color:rgba(46,204,113,.45)}
-  .chip-pending{border-color:rgba(241,196,15,.55)}
-  .chip-booked{border-color:rgba(52,152,219,.55)}
-  #flt select{padding:8px 12px;border-radius:var(--radius-md);border:1px solid var(--field-border);background:var(--field-bg);color:inherit;box-shadow:var(--field-shadow)}
-  #flt button{border-radius:var(--radius-md);padding:10px 16px;}
-
-  /* table */
-  .tbl-wrap{overflow:auto;border-radius:12px}
-  thead th{position:sticky;top:0;background:linear-gradient(180deg, rgba(255,255,255,.08), rgba(255,255,255,.02));}
-  tbody tr{transition:background .15s ease}
-  .row-free    td{background:rgba(46,204,113,.06)}
-  .row-pending td{background:rgba(241,196,15,.06)}
-  .row-booked  td{background:rgba(52,152,219,.06)}
-  .copyable{cursor:pointer;border-bottom:1px dashed rgba(255,255,255,.35)}
-  .copyable:hover{opacity:.9}
-  .muted-mini{font-size:12px;color:var(--muted)}
-  .hidden-col{display:none}
-
-  /* sorting */
-  th.sortable{cursor:pointer; user-select:none;}
-  th.sortable .dir{opacity:.5; margin-left:4px; font-size:11px}
-  th.sortable.active{color:#fff}
-
-  /* hover focus */
-  tbody tr:hover td{background:rgba(255,255,255,.03)}
-</style>
-
-<h3 class="tilt" data-tilt data-tilt-max="2" data-tilt-speed="1200" data-tilt-scale="1.005" style="margin:0 0 10px 0;">Слоты</h3>
-
-<div class="card tilt toolbar" data-tilt data-tilt-glare data-tilt-max="8" data-tilt-speed="600" data-tilt-scale="1.01" style="margin-bottom:12px;">
-  <form id="flt" method="get" action="/slots" style="display:flex; gap:16px; align-items:flex-end; flex-wrap:wrap;">
-    <div style="display:flex; flex-direction:column; gap:6px; min-width:220px;">
+  {% call list_toolbar(
+    form_id="flt",
+    form_action="/slots",
+    method="get",
+    sticky=True,
+    mass_actions=[{'label': 'Показать', 'type': 'button', 'variant': 'primary', 'button_type': 'submit'}],
+    chips=[
+      {'label': 'FREE', 'value': status_counts.FREE, 'tone': 'success', 'value_id': 'cnt-free'},
+      {'label': 'PENDING', 'value': status_counts.PENDING, 'tone': 'warning', 'value_id': 'cnt-pending'},
+      {'label': 'BOOKED', 'value': status_counts.BOOKED, 'tone': 'info', 'value_id': 'cnt-booked'},
+      {'label': 'Всего', 'value': status_counts.total, 'value_id': 'cnt-total'}
+    ]
+  ) %}
+    <div class="form-field">
       <label for="recruiter_id">Рекрутёр</label>
       <select id="recruiter_id" name="recruiter_id">
         <option value="">— все —</option>
@@ -50,7 +40,7 @@
       </select>
     </div>
 
-    <div style="display:flex; flex-direction:column; gap:6px; min-width:160px;">
+    <div class="form-field form-field--narrow">
       <label for="status">Статус</label>
       <select id="status" name="status">
         <option value="">— все —</option>
@@ -60,138 +50,140 @@
       </select>
     </div>
 
-    <div style="display:flex; flex-direction:column; gap:6px; min-width:140px;">
+    <div class="form-field form-field--narrow">
       <label for="per_page">На странице</label>
       <select id="per_page" name="per_page">
-        {% for n in [10,20,50,100] %}
+        {% for n in [10, 20, 50, 100] %}
           <option value="{{ n }}" {% if per_page == n %}selected{% endif %}>{{ n }}</option>
         {% endfor %}
       </select>
     </div>
 
-    <div style="display:flex; gap:10px; align-items:center; flex-wrap:wrap;">
-      <label class="badge" style="cursor:pointer;">
-        <input id="toggle_cand_tz" type="checkbox" style="margin-right:6px;"> Время кандидата
+    <div class="field-stack">
+      <label class="form-toggle" for="toggle_cand_tz">
+        <input id="toggle_cand_tz" type="checkbox"> Время кандидата
       </label>
-      <label class="badge" style="cursor:pointer;">
-        <input id="only_future" type="checkbox" style="margin-right:6px;"> Только будущие
+      <label class="form-toggle" for="only_future">
+        <input id="only_future" type="checkbox"> Только будущие
       </label>
-      <button type="submit" class="btn">Показать</button>
-      <a class="btn" href="/slots/new">+ Новый слот</a>
     </div>
-  </form>
+  {% endcall %}
 
-  <div class="chips" style="margin-top:12px;">
-    <span class="chip chip-free">FREE: <b id="cnt-free">{{ status_counts.FREE }}</b></span>
-    <span class="chip chip-pending">PENDING: <b id="cnt-pending">{{ status_counts.PENDING }}</b></span>
-    <span class="chip chip-booked">BOOKED: <b id="cnt-booked">{{ status_counts.BOOKED }}</b></span>
-    <span class="chip">Всего: <b id="cnt-total">{{ status_counts.total }}</b></span>
-  </div>
-</div>
-
-{% if not slots %}
-  <div class="card tilt" data-tilt data-tilt-glare data-tilt-max="6" data-tilt-speed="500">
-    <h4>Пусто</h4>
-    <p>Слотов по выбранным условиям нет.</p>
-  </div>
-{% else %}
-  <div class="card tilt tbl-wrap" data-tilt data-tilt-glare data-tilt-max="6" data-tilt-speed="600">
-    <table id="slots-table">
-      <thead>
-        <tr>
-          <th class="sortable" data-sort="id"     title="Сортировать по ID">ID <span class="dir"></span></th>
-          <th class="sortable" data-sort="rec"    title="Сортировать по рекрутёру">Рекрутёр <span class="dir"></span></th>
-          <th class="sortable" data-sort="utc"    style="width:160px;" title="Сортировать по UTC">UTC <span class="dir"></span></th>
-          <th                                   style="width:210px;">Локальное (TZ рекрутёра)</th>
-          <th style="width:210px;" class="col-cand-tz">Локальное (TZ кандидата)</th>
-          <th class="sortable" data-sort="status" style="width:120px;" title="Сортировать по статусу">Статус <span class="dir"></span></th>
-          <th class="sortable" data-sort="cand"   title="Сортировать по кандидату">Кандидат <span class="dir"></span></th>
-        </tr>
-      </thead>
-      <tbody>
-      {% for s in slots %}
-        {% set st = norm_status(s.status) %}
-        {% set row_cls = 'row-free' if st=='FREE' else ('row-pending' if st=='PENDING' else ('row-booked' if st=='BOOKED' else '')) %}
-        <tr class="{{ row_cls }}" data-st="{{ st or '' }}" data-id="{{ s.id }}" data-utc="{{ s.start_utc.isoformat() }}" data-rec="{{ s.recruiter.name if s.recruiter else '' }}" data-cand="{{ s.candidate_fio or '' }}" data-sto="{{ 0 if st=='FREE' else (1 if st=='PENDING' else (2 if st=='BOOKED' else 9)) }}">
-          <td>
-            <span class="copyable" data-copy="{{ s.id }}" title="Скопировать ID">{{ s.id }}</span>
-          </td>
-          <td>
-            {{ s.recruiter.name if s.recruiter else "—" }}<br>
-            <span class="badge">{{ (s.recruiter.tz if s.recruiter and s.recruiter.tz else "Europe/Moscow") }}</span>
-          </td>
-          <td>
-            <span class="copyable" data-copy="{{ fmt_utc(s.start_utc) }}" title="Скопировать UTC-время" data-utc-iso="{{ s.start_utc.isoformat() }}">
-              {{ fmt_utc(s.start_utc) }}
-            </span>
-            <div class="muted-mini" data-rel></div>
-          </td>
-          <td>
-            {% set tz_rec = (s.recruiter.tz if s.recruiter and s.recruiter.tz else "Europe/Moscow") %}
-            <span class="copyable" data-copy="{{ fmt_local(s.start_utc, tz_rec) }}" title="Скопировать локальное время рекрутёра">
-              {{ fmt_local(s.start_utc, tz_rec) }}
-            </span>
-          </td>
-          <td class="col-cand-tz">
-            {% if s.candidate_tz %}
-              <span class="badge">{{ s.candidate_tz }}</span><br>
-              <span class="copyable" data-copy="{{ fmt_local(s.start_utc, s.candidate_tz) }}" title="Скопировать локальное время кандидата">
-                {{ fmt_local(s.start_utc, s.candidate_tz) }}
+  {% if not slots %}
+    <div class="card glass grain">
+      <h3 class="section-title">Пусто</h3>
+      <p class="page-description">Слотов по выбранным условиям нет.</p>
+    </div>
+  {% else %}
+    <div class="list-table-wrapper">
+      <table id="slots-table" class="list-table list-table--responsive">
+        <thead>
+          <tr>
+            <th class="sortable" data-sort="id">ID <span class="dir"></span></th>
+            <th class="sortable" data-sort="rec">Рекрутёр <span class="dir"></span></th>
+            <th class="sortable" data-sort="utc">UTC <span class="dir"></span></th>
+            <th>Локальное (TZ рекрутёра)</th>
+            <th class="col-cand-tz is-optional">Локальное (TZ кандидата)</th>
+            <th class="sortable" data-sort="status">Статус <span class="dir"></span></th>
+            <th class="sortable" data-sort="cand">Кандидат <span class="dir"></span></th>
+            <th class="is-optional">Детали</th>
+          </tr>
+        </thead>
+        <tbody>
+        {% for s in slots %}
+          {% set st = norm_status(s.status) %}
+          {% set row_cls = 'row-free' if st=='FREE' else ('row-pending' if st=='PENDING' else ('row-booked' if st=='BOOKED' else '')) %}
+          <tr class="{{ row_cls }}" data-st="{{ st or '' }}" data-id="{{ s.id }}" data-utc="{{ s.start_utc.isoformat() }}" data-rec="{{ s.recruiter.name if s.recruiter else '' }}" data-cand="{{ s.candidate_fio or '' }}" data-sto="{{ 0 if st=='FREE' else (1 if st=='PENDING' else (2 if st=='BOOKED' else 9)) }}">
+            <td data-label="ID">
+              <span class="copyable" data-copy="{{ s.id }}" title="Скопировать ID">{{ s.id }}</span>
+            </td>
+            <td data-label="Рекрутёр">
+              <div>{{ s.recruiter.name if s.recruiter else "—" }}</div>
+              <div class="badge">{{ (s.recruiter.tz if s.recruiter and s.recruiter.tz else "Europe/Moscow") }}</div>
+            </td>
+            <td data-label="UTC">
+              <span class="copyable" data-copy="{{ fmt_utc(s.start_utc) }}" title="Скопировать UTC-время" data-utc-iso="{{ s.start_utc.isoformat() }}">
+                {{ fmt_utc(s.start_utc) }}
               </span>
-            {% else %}
-              <span class="badge">—</span>
-            {% endif %}
-          </td>
-          <td>
-            {% if st == "FREE" %}
-              <span class="badge status-chip" data-status="FREE">FREE</span>
-            {% elif st == "PENDING" %}
-              <span class="badge status-chip" data-status="PENDING" style="color:#f1c40f;">PENDING</span>
-            {% elif st == "BOOKED" %}
-              <span class="badge status-chip" data-status="BOOKED" style="color:#2ecc71;">BOOKED</span>
-            {% else %}
-              <span class="badge">{{ st or "—" }}</span>
-            {% endif %}
-          </td>
-          <td>
-            {% if s.candidate_fio %}
-              <div>{{ s.candidate_fio }}</div>
-              <div class="badge copyable" data-copy="{{ s.candidate_tg_id or '' }}" title="Скопировать tg_id">tg_id: {{ s.candidate_tg_id or "—" }}</div>
-            {% else %}
-              <span class="badge">—</span>
-            {% endif %}
-          </td>
-        </tr>
-      {% endfor %}
-      </tbody>
-    </table>
-  </div>
+              <div class="muted" data-rel></div>
+            </td>
+            <td data-label="Локальное (рекрутёр)">
+              {% set tz_rec = (s.recruiter.tz if s.recruiter and s.recruiter.tz else "Europe/Moscow") %}
+              <span class="copyable" data-copy="{{ fmt_local(s.start_utc, tz_rec) }}" title="Скопировать локальное время рекрутёра">
+                {{ fmt_local(s.start_utc, tz_rec) }}
+              </span>
+            </td>
+            <td class="col-cand-tz is-optional" data-label="Кандидат TZ">
+              {% if s.candidate_tz %}
+                <div class="badge">{{ s.candidate_tz }}</div>
+                <span class="copyable" data-copy="{{ fmt_local(s.start_utc, s.candidate_tz) }}" title="Скопировать локальное время кандидата">
+                  {{ fmt_local(s.start_utc, s.candidate_tz) }}
+                </span>
+              {% else %}
+                <span class="badge">—</span>
+              {% endif %}
+            </td>
+            <td data-label="Статус">
+              {% if st == "FREE" %}
+                <span class="status-badge" data-tone="success">FREE</span>
+              {% elif st == "PENDING" %}
+                <span class="status-badge" data-tone="warning">PENDING</span>
+              {% elif st == "BOOKED" %}
+                <span class="status-badge" data-tone="info">BOOKED</span>
+              {% else %}
+                <span class="badge">{{ st or "—" }}</span>
+              {% endif %}
+            </td>
+            <td data-label="Кандидат">
+              {% if s.candidate_fio %}
+                <div>{{ s.candidate_fio }}</div>
+                <div class="badge copyable" data-copy="{{ s.candidate_tg_id or '' }}" title="Скопировать tg_id">tg_id: {{ s.candidate_tg_id or "—" }}</div>
+              {% else %}
+                <span class="badge">—</span>
+              {% endif %}
+            </td>
+            <td class="list-table__details" data-label="">
+              <details>
+                <summary>Подробнее</summary>
+                <div class="meta-list">
+                  <span>UTC: {{ fmt_utc(s.start_utc) }}</span>
+                  <span>Рекрутёр: {{ s.recruiter.name if s.recruiter else '—' }}</span>
+                  {% if s.candidate_fio %}<span>Кандидат: {{ s.candidate_fio }}</span>{% endif %}
+                  {% if s.candidate_tz %}<span>TZ кандидата: {{ s.candidate_tz }}</span>{% endif %}
+                </div>
+              </details>
+            </td>
+          </tr>
+        {% endfor %}
+        </tbody>
+      </table>
+    </div>
 
-  <!-- пагинация -->
-  <div class="tilt" data-tilt data-tilt-max="3" data-tilt-speed="800" style="display:flex; align-items:center; gap:8px; margin-top:10px; flex-wrap:wrap;">
-    {% set qrecr = '&recruiter_id=' ~ filter_recruiter_id if filter_recruiter_id else '' %}
-    {% set qstat = '&status=' ~ filter_status if filter_status else '' %}
-    {% set qpp = '&per_page=' ~ per_page if per_page else '' %}
+    <div class="pagination">
+      {% set qrecr = '&recruiter_id=' ~ filter_recruiter_id if filter_recruiter_id else '' %}
+      {% set qstat = '&status=' ~ filter_status if filter_status else '' %}
+      {% set qpp = '&per_page=' ~ per_page if per_page else '' %}
 
-    <span class="badge">Стр. {{ page }} из {{ pages_total }}</span>
+      <span class="badge">Стр. {{ page }} из {{ pages_total }}</span>
 
-    {% if page > 1 %}
-      <a class="btn" href="/slots?page=1{{ qrecr }}{{ qstat }}{{ qpp }}">« Первая</a>
-      <a class="btn" href="/slots?page={{ page-1 }}{{ qrecr }}{{ qstat }}{{ qpp }}">‹ Назад</a>
-    {% else %}
-      <span class="btn" style="opacity:.4; pointer-events:none;">« Первая</span>
-      <span class="btn" style="opacity:.4; pointer-events:none;">‹ Назад</span>
-    {% endif %}
+      {% if page > 1 %}
+        <a class="btn btn-ghost" href="/slots?page=1{{ qrecr }}{{ qstat }}{{ qpp }}">« Первая</a>
+        <a class="btn btn-ghost" href="/slots?page={{ page-1 }}{{ qrecr }}{{ qstat }}{{ qpp }}">‹ Назад</a>
+      {% else %}
+        <span class="btn btn-ghost" aria-disabled="true">« Первая</span>
+        <span class="btn btn-ghost" aria-disabled="true">‹ Назад</span>
+      {% endif %}
 
-    {% if page < pages_total %}
-      <a class="btn" href="/slots?page={{ page+1 }}{{ qrecr }}{{ qstat }}{{ qpp }}">Вперёд ›</a>
-      <a class="btn" href="/slots?page={{ pages_total }}{{ qrecr }}{{ qstat }}{{ qpp }}">Последняя »</a>
-    {% else %}
-      <span class="btn" style="opacity:.4; pointer-events:none;">Вперёд ›</span>
-      <span class="btn" style="opacity:.4; pointer-events:none;">Последняя »</span>
-    {% endif %}
-  </div>
-{% endif %}
+      {% if page < pages_total %}
+        <a class="btn btn-ghost" href="/slots?page={{ page+1 }}{{ qrecr }}{{ qstat }}{{ qpp }}">Вперёд ›</a>
+        <a class="btn btn-ghost" href="/slots?page={{ pages_total }}{{ qrecr }}{{ qstat }}{{ qpp }}">Последняя »</a>
+      {% else %}
+        <span class="btn btn-ghost" aria-disabled="true">Вперёд ›</span>
+        <span class="btn btn-ghost" aria-disabled="true">Последняя »</span>
+      {% endif %}
+    </div>
+  {% endif %}
+</section>
 
 {% raw %}
 <script>
@@ -234,10 +226,14 @@
         if(st==='FREE') free++; else if(st==='PENDING') pend++; else if(st==='BOOKED') book++;
       }
     });
-    $('#cnt-total').textContent = total;
-    $('#cnt-free').textContent = free;
-    $('#cnt-pending').textContent = pend;
-    $('#cnt-booked').textContent = book;
+    var totalEl = $('#cnt-total');
+    if(totalEl) totalEl.textContent = total;
+    var freeEl = $('#cnt-free');
+    if(freeEl) freeEl.textContent = free;
+    var pendEl = $('#cnt-pending');
+    if(pendEl) pendEl.textContent = pend;
+    var bookEl = $('#cnt-booked');
+    if(bookEl) bookEl.textContent = book;
   }
 
   if(onlyFuture){
@@ -282,15 +278,21 @@
   var sortDir = 'asc';
 
   function applySortIndicator(){
-    $$('#slots-table thead th.sortable').forEach(function(th){ th.classList.remove('active'); var d = th.querySelector('.dir'); if(d) d.textContent=''; });
+    $$('#slots-table thead th.sortable').forEach(function(th){
+      th.classList.remove('active');
+      var d = th.querySelector('.dir');
+      if(d) d.textContent='';
+    });
     var th = $('#slots-table thead th.sortable[data-sort="'+sortKey+'"]');
     if (th){
       th.classList.add('active');
-      var d = th.querySelector('.dir'); if(d) d.textContent = sortDir==='asc' ? '▲' : '▼';
+      var d = th.querySelector('.dir');
+      if(d) d.textContent = sortDir==='asc' ? '▲' : '▼';
     }
   }
 
   function cmp(a,b){ return a<b?-1:a>b?1:0; }
+
   function sortRows(){
     var tbody = $('#slots-table tbody');
     var arr = rows.slice();
@@ -318,13 +320,11 @@
     });
   });
 
-  // Keyboard shortcuts: 't' toggle candidate TZ, 'f' toggle future filter
   document.addEventListener('keydown', function(e){
     if(e.key==='t' && candTzToggle){ candTzToggle.checked = !candTzToggle.checked; candTzToggle.dispatchEvent(new Event('change')); }
     if(e.key==='f' && onlyFuture){ onlyFuture.checked = !onlyFuture.checked; onlyFuture.dispatchEvent(new Event('change')); }
   });
 
-  // First run
   applySortIndicator();
   sortRows();
   refreshCounts();

--- a/backend/apps/admin_ui/templates/templates_list.html
+++ b/backend/apps/admin_ui/templates/templates_list.html
@@ -1,109 +1,102 @@
 {% extends "base.html" %}
 {% block title %}Шаблоны сообщений{% endblock %}
 {% block content %}
-
-<div class="card glass grain" style="margin-bottom:16px; padding:16px;">
-  <h2 style="margin:0 0 8px;">Шаблоны по этапам</h2>
-  <p class="muted" style="margin:0;">
-    Здесь можно настроить тексты, которые бот отправляет кандидату на каждом шаге процесса. Если поле оставить пустым,
-    бот возьмёт текст по умолчанию.
-  </p>
-  <ol class="stage-flow muted">
-    <li><strong>Шаг 1.</strong> После Теста 1 кандидат получает приглашение выбрать время для видеоинтервью.</li>
-    <li><strong>Шаг 2.</strong> За 2 часа до интервью бот отправляет напоминание с запросом подтверждения.</li>
-    <li><strong>Шаг 3.</strong> После успешного собеседования и согласования даты бот приглашает на ознакомительный день.</li>
-    <li><strong>Шаг 4.</strong> За 2 часа до ознакомительного дня бот просит подтвердить явку (кнопки «Подтверждаю/Не смогу»).</li>
-  </ol>
-  <div class="badge" style="margin-top:4px; display:inline-flex; gap:8px; align-items:center; flex-wrap:wrap;">
-    {% raw %}
-    Доступные переменные: <code>{{candidate_fio}}</code>, <code>{{city_name}}</code>, <code>{{interview_dt_hint}}</code>,
-    <code>{{slot_date_local}}</code>, <code>{{slot_time_local}}</code>, <code>{{slot_datetime_local}}</code>,
-    <code>{{recruiter_name}}</code>, <code>{{address}}</code>.
-    {% endraw %}
-  </div>
-</div>
-
-<section class="card glass tilt" data-tilt data-tilt-max="4" data-tilt-speed="400" style="margin-bottom:18px;">
-  <header style="display:flex; justify-content:space-between; align-items:center; gap:10px; flex-wrap:wrap;">
+<section class="page">
+  <header class="page-header">
     <div>
-      <h3 style="margin:0;">Глобальные шаблоны</h3>
-      <p class="muted" style="margin:4px 0 0;">Используются, если для города нет своего текста.</p>
+      <h1 class="page-title">Шаблоны сообщений</h1>
+      <p class="page-description">
+        Настройте тексты, которые бот отправляет кандидату на каждом шаге процесса. Пустые поля используют текст по умолчанию.
+      </p>
     </div>
   </header>
-  <form class="template-form" data-city="" autocomplete="off" style="margin-top:14px;">
-    {% for stage in overview.global.stages %}
-      <div class="field stage-field" data-stage="{{ stage.key }}">
-        <label for="global_{{ stage.key }}">{{ stage.title }}</label>
-        <textarea
-          id="global_{{ stage.key }}"
-          data-stage="{{ stage.key }}"
-          data-default="{{ stage.default|e }}"
-          rows="6"
-          placeholder="{{ stage.default|e }}">{{ stage.value }}</textarea>
-        <div class="stage-controls">
-          <button type="button" class="btn mini ghost stage-default">Вставить стандартный текст</button>
-          <span class="muted">{{ stage.description }}</span>
+
+  <div class="card glass grain">
+    <h2 class="section-title">Этапы коммуникации</h2>
+    <ol class="stage-flow muted">
+      <li><strong>Шаг 1.</strong> После Теста 1 кандидат получает приглашение выбрать время для видеоинтервью.</li>
+      <li><strong>Шаг 2.</strong> За 2 часа до интервью бот отправляет напоминание с запросом подтверждения.</li>
+      <li><strong>Шаг 3.</strong> После успешного собеседования и согласования даты бот приглашает на ознакомительный день.</li>
+      <li><strong>Шаг 4.</strong> За 2 часа до ознакомительного дня бот просит подтвердить явку (кнопки «Подтверждаю/Не смогу»).</li>
+    </ol>
+    <div class="badge info-badge">
+      {% raw %}
+      Доступные переменные: <code>{{candidate_fio}}</code>, <code>{{city_name}}</code>, <code>{{interview_dt_hint}}</code>,
+      <code>{{slot_date_local}}</code>, <code>{{slot_time_local}}</code>, <code>{{slot_datetime_local}}</code>,
+      <code>{{recruiter_name}}</code>, <code>{{address}}</code>.
+      {% endraw %}
+    </div>
+  </div>
+
+  <section class="card glass tilt" data-tilt data-tilt-max="4" data-tilt-speed="400">
+    <header class="page-header">
+      <div>
+        <h3 class="card-title">Глобальные шаблоны</h3>
+        <p class="page-description">Используются, если для города нет собственного текста.</p>
+      </div>
+    </header>
+    <form class="template-form" data-city="" autocomplete="off">
+      {% for stage in overview.global.stages %}
+        <div class="stage-field" data-stage="{{ stage.key }}">
+          <label for="global_{{ stage.key }}">{{ stage.title }}</label>
+          <textarea
+            id="global_{{ stage.key }}"
+            data-stage="{{ stage.key }}"
+            data-default="{{ stage.default|e }}"
+            rows="6"
+            placeholder="{{ stage.default|e }}">{{ stage.value }}</textarea>
+          <div class="stage-controls">
+            <button type="button" class="btn btn-ghost btn--small stage-default">Вставить стандартный текст</button>
+            <span class="muted">{{ stage.description }}</span>
+          </div>
         </div>
+      {% endfor %}
+      <div class="form-actions">
+        <button type="submit" class="btn btn-primary">Сохранить глобальные</button>
+        <span class="badge muted save-status">Сохранено</span>
+      </div>
+    </form>
+  </section>
+
+  <section class="city-collection">
+    {% for entry in overview.cities %}
+      <article class="card glass grain city-card" data-city="{{ entry.city.id }}">
+        <header class="city-card__header">
+          <div class="city-card__title">
+            <span class="city-name">{{ entry.city.name }}</span>
+            <span class="badge" title="Часовой пояс">{{ entry.city.tz or "Europe/Moscow" }}</span>
+          </div>
+        </header>
+        <form class="template-form" data-city="{{ entry.city.id }}" autocomplete="off">
+          {% for stage in entry.stages %}
+            <div class="stage-field" data-stage="{{ stage.key }}">
+              <label for="stage_{{ entry.city.id }}_{{ stage.key }}">{{ stage.title }}</label>
+              <textarea
+                id="stage_{{ entry.city.id }}_{{ stage.key }}"
+                data-stage="{{ stage.key }}"
+                data-default="{{ stage.default|e }}"
+                rows="6"
+                placeholder="{{ stage.default|e }}">{{ stage.value }}</textarea>
+              <div class="stage-controls">
+                <button type="button" class="btn btn-ghost btn--small stage-default">Вставить стандартный текст</button>
+                <span class="muted">{{ stage.description }}</span>
+              </div>
+            </div>
+          {% endfor %}
+          <div class="form-actions">
+            <button type="submit" class="btn btn-primary">Сохранить</button>
+            <span class="badge muted save-status">Сохранено</span>
+          </div>
+        </form>
+      </article>
+    {% else %}
+      <div class="card glass grain">
+        <h3 class="section-title">Пока нет городов</h3>
+        <p class="page-description">Добавьте город, чтобы настроить городские сообщения.</p>
       </div>
     {% endfor %}
-    <div class="actions">
-      <button type="submit">Сохранить глобальные</button>
-      <span class="badge muted save-status" style="display:none;">Сохранено</span>
-    </div>
-  </form>
+  </section>
 </section>
-
-<section class="cards city-templates">
-  {% for entry in overview.cities %}
-    <article class="card glass grain city-card" data-city="{{ entry.city.id }}">
-      <header class="city-header">
-        <h4 style="margin:0;">{{ entry.city.name }}</h4>
-        <span class="badge" title="Часовой пояс">{{ entry.city.tz or "Europe/Moscow" }}</span>
-      </header>
-      <form class="template-form" data-city="{{ entry.city.id }}" autocomplete="off">
-        {% for stage in entry.stages %}
-          <div class="field stage-field" data-stage="{{ stage.key }}">
-            <label for="stage_{{ entry.city.id }}_{{ stage.key }}">{{ stage.title }}</label>
-            <textarea
-              id="stage_{{ entry.city.id }}_{{ stage.key }}"
-              data-stage="{{ stage.key }}"
-              data-default="{{ stage.default|e }}"
-              rows="6"
-              placeholder="{{ stage.default|e }}">{{ stage.value }}</textarea>
-            <div class="stage-controls">
-              <button type="button" class="btn mini ghost stage-default">Вставить стандартный текст</button>
-              <span class="muted">{{ stage.description }}</span>
-            </div>
-          </div>
-        {% endfor %}
-        <div class="actions">
-          <button type="submit">Сохранить</button>
-          <span class="badge muted save-status" style="display:none;">Сохранено</span>
-        </div>
-      </form>
-    </article>
-  {% else %}
-    <div class="card glass grain">
-      <h4 style="margin:0 0 6px;">Пока нет городов</h4>
-      <p class="muted" style="margin:0;">Добавьте город, чтобы настроить городские сообщения.</p>
-    </div>
-  {% endfor %}
-</section>
-
-<style>
-  .city-templates { display:grid; gap:16px; grid-template-columns:repeat(auto-fit, minmax(320px, 1fr)); }
-  .stage-field { display:flex; flex-direction:column; gap:6px; margin-bottom:14px; }
-  .stage-field textarea { min-height:140px; resize:vertical; }
-  .stage-controls { display:flex; align-items:center; gap:10px; flex-wrap:wrap; }
-  .actions { display:flex; gap:10px; align-items:center; margin-top:12px; }
-  .city-header { display:flex; justify-content:space-between; align-items:center; gap:8px; margin-bottom:12px; }
-  .city-card form { margin-top:4px; }
-  .stage-default { border-color:var(--row-sep); background:transparent; }
-  .save-status.ok { color: var(--ok); }
-  .save-status.err { color: var(--bad); }
-  .stage-flow { margin:12px 0 0; padding-left:20px; display:flex; flex-direction:column; gap:6px; }
-  .stage-flow li { margin:0; }
-</style>
 
 <script>
 (function(){
@@ -162,5 +155,4 @@
   });
 })();
 </script>
-
 {% endblock %}


### PR DESCRIPTION
## Summary
- add shared list CSS tokens and toolbar macro for filters, chips, and mass actions
- refactor recruiter, slot, city, template, and question list templates to use shared components and responsive data patterns
- normalize status badges, chips, and action buttons for consistent touch-friendly interactions across admin lists

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da18df0ea0833385d703a7ff9aed67