### PR TITLE
Add recruiter identity command handler

### DIFF
--- a/backend/apps/bot/__init__.py
+++ b/backend/apps/bot/__init__.py
@@ -1,7 +1,9 @@
 """Bot application package exports."""
 
-from .app import create_application, create_bot, create_dispatcher, main
-from .services import StateManager
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Any
 
 __all__ = [
     "create_application",
@@ -10,3 +12,22 @@ __all__ = [
     "main",
     "StateManager",
 ]
+
+
+def __getattr__(name: str) -> Any:
+    if name == "StateManager":
+        from .services import StateManager as _StateManager
+
+        return _StateManager
+
+    if name in {"create_application", "create_bot", "create_dispatcher", "main"}:
+        app_module = import_module(".app", __name__)
+        attr = getattr(app_module, name)
+        globals()[name] = attr
+        return attr
+
+    raise AttributeError(name)
+
+
+def __dir__() -> list[str]:
+    return sorted(set(globals()) | set(__all__))

--- a/backend/apps/bot/config.py
+++ b/backend/apps/bot/config.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Optional, Tuple, TypedDict
 
+import logging
+
 from aiogram.client.bot import DefaultBotProperties
 from aiogram.enums import ParseMode
 
@@ -48,7 +50,13 @@ class State(TypedDict, total=False):
     picked_slot_id: Optional[int]
 
 
-_QUESTIONS_BANK = load_all_test_questions()
+try:
+    _QUESTIONS_BANK = load_all_test_questions()
+except Exception:  # pragma: no cover - fallback for missing DB tables
+    logging.getLogger(__name__).warning(
+        "Falling back to default test questions; database is not available."
+    )
+    _QUESTIONS_BANK = DEFAULT_TEST_QUESTIONS
 TEST2_QUESTIONS: List[Dict[str, Any]] = (
     _QUESTIONS_BANK.get("test2", DEFAULT_TEST_QUESTIONS.get("test2", [])).copy()
 )

--- a/backend/apps/bot/handlers/__init__.py
+++ b/backend/apps/bot/handlers/__init__.py
@@ -11,6 +11,7 @@ __all__ = ["register_routers"]
 
 def register_routers(dp: Dispatcher) -> None:
     """Include all bot routers into the dispatcher."""
+    # common router contains generic commands such as /start and /iam
     dp.include_router(common.router)
     dp.include_router(test1.router)
     dp.include_router(test2.router)

--- a/backend/apps/bot/handlers/recruiter.py
+++ b/backend/apps/bot/handlers/recruiter.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 from aiogram import F, Router
-from aiogram.types import CallbackQuery
+from aiogram.filters import Command
+from aiogram.types import CallbackQuery, Message
 
 from .. import services
 
@@ -18,3 +19,8 @@ async def approve(callback: CallbackQuery) -> None:
 @router.callback_query(F.data.startswith("reject:"))
 async def reject(callback: CallbackQuery) -> None:
     await services.handle_reject_slot(callback)
+
+
+@router.message(Command("iam"))
+async def cmd_iam(message: Message) -> None:
+    await services.handle_recruiter_identity_command(message)

--- a/backend/apps/bot/services.py
+++ b/backend/apps/bot/services.py
@@ -25,6 +25,7 @@ from backend.domain.repositories import (
     get_slot,
     reject_slot,
     reserve_slot,
+    set_recruiter_chat_id_by_command,
 )
 
 from . import templates
@@ -303,6 +304,28 @@ async def send_welcome(user_id: int) -> None:
         "Нажмите «Начать», чтобы заполнить мини-анкету и выбрать время для интервью."
     )
     await bot.send_message(user_id, text, reply_markup=kb_start())
+
+
+async def handle_recruiter_identity_command(message: Message) -> None:
+    """Process the `/iam` command sent by a recruiter."""
+
+    text = (message.text or "").strip()
+    _, _, args = text.partition(" ")
+    name_hint = args.strip()
+    if not name_hint:
+        await message.answer("Используйте команду в формате: /iam <Имя>")
+        return
+
+    updated = await set_recruiter_chat_id_by_command(name_hint, chat_id=message.chat.id)
+    if not updated:
+        await message.answer(
+            "Рекрутер не найден. Убедитесь, что имя совпадает с записью в системе."
+        )
+        return
+
+    await message.answer(
+        "Готово! Уведомления о брони и подтверждениях будут приходить в этот чат."
+    )
 
 
 async def start_introday_flow(message: Message) -> None:


### PR DESCRIPTION
## Summary
- add a /iam command handler for recruiters that invokes the repository update logic
- validate recruiter command arguments in the service layer and send feedback messages
- cover the new workflow with an async repository test and harden bot config imports

## Testing
- pytest tests/test_domain_repositories.py

------
https://chatgpt.com/codex/tasks/task_e_68da1f7b881c8333b2aa0917d02e06fe