### PR TITLE
Restyle recruiters page layout

### DIFF
--- a/backend/apps/admin_ui/static/css/lists.css
+++ b/backend/apps/admin_ui/static/css/lists.css
@@ -274,8 +274,9 @@ button:disabled,
 /* Card grids */
 .card-grid {
   display: grid;
-  gap: 16px;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 24px;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  align-items: stretch;
 }
 
 .card-title {
@@ -287,34 +288,96 @@ button:disabled,
 .recruiter-card {
   display: flex;
   flex-direction: column;
-  gap: 14px;
-  padding: 18px;
-  border-radius: var(--radius-lg);
-  border: 1px solid var(--glass-stroke);
-  background: linear-gradient(180deg, rgba(255,255,255,.07), rgba(255,255,255,.02));
-  box-shadow: var(--shadow-1);
-  min-height: 240px;
+  gap: 20px;
+  padding: 24px;
+  border-radius: 20px;
+  border: 1px solid color-mix(in srgb, var(--glass-stroke) 60%, transparent);
+  background: linear-gradient(180deg,
+    color-mix(in srgb, var(--glass-tint) 72%, transparent),
+    color-mix(in srgb, var(--glass-bottom) 45%, transparent));
+  backdrop-filter: blur(22px) saturate(1.12);
+  box-shadow: var(--shadow-2);
+  min-height: 260px;
+  transition: transform .25s ease, box-shadow .25s ease;
+}
+
+.recruiter-card:hover {
+  transform: translateY(-4px);
+  box-shadow: var(--shadow-3);
 }
 
 .recruiter-card__header {
   display: flex;
   flex-wrap: wrap;
   justify-content: space-between;
-  gap: 12px;
-  align-items: flex-start;
+  gap: 16px;
+  align-items: center;
 }
 
 .recruiter-card__name {
   margin: 0;
-  font-size: 20px;
+  font-size: 22px;
+  font-weight: 650;
 }
 
 .meta-list {
   display: flex;
   flex-wrap: wrap;
-  gap: 6px;
-  color: var(--muted);
+  gap: 12px;
+  color: color-mix(in srgb, var(--muted) 80%, transparent);
   font-size: 12px;
+}
+
+.recruiter-card__identity {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.recruiter-card__body {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 18px;
+}
+
+.recruiter-card__section {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 16px;
+  border-radius: 16px;
+  border: 1px solid color-mix(in srgb, var(--glass-stroke) 40%, transparent);
+  background: linear-gradient(180deg,
+    color-mix(in srgb, var(--glass-tint) 50%, transparent),
+    color-mix(in srgb, rgba(0,0,0,.20) 12%, transparent));
+}
+
+.recruiter-metrics {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 12px;
+  margin: 0;
+}
+
+.recruiter-metrics div {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.recruiter-metrics dt {
+  margin: 0;
+  font-size: 12px;
+  letter-spacing: .3px;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--muted) 90%, transparent);
+}
+
+.recruiter-metrics dd {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 600;
+  color: var(--fg-strong);
 }
 
 .chip-row {
@@ -333,7 +396,8 @@ button:disabled,
   margin-top: auto;
   display: flex;
   flex-wrap: wrap;
-  gap: 8px;
+  gap: 12px;
+  justify-content: flex-end;
 }
 
 .section-block {
@@ -603,6 +667,11 @@ button:disabled,
 
 /* Responsive table conversions */
 @media (max-width: 960px) {
+  .card-grid {
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 20px;
+  }
+
   .list-toolbar__actions {
     width: 100%;
     justify-content: flex-start;
@@ -691,6 +760,24 @@ button:disabled,
     justify-content: flex-start;
   }
 
+  .card-grid {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 18px;
+  }
+
+  .recruiter-card {
+    padding: 20px;
+  }
+
+  .recruiter-card__body {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 16px;
+  }
+
+  .recruiter-card__footer {
+    justify-content: flex-start;
+  }
+
   .recruiter-card__footer .btn {
     flex: 1 1 100%;
   }
@@ -705,5 +792,20 @@ button:disabled,
 
   .chip {
     font-size: 11px;
+  }
+}
+
+@media (max-width: 480px) {
+  .recruiter-card {
+    padding: 18px;
+    border-radius: 16px;
+  }
+
+  .recruiter-card__name {
+    font-size: 20px;
+  }
+
+  .meta-list {
+    gap: 8px;
   }
 }

--- a/backend/apps/admin_ui/templates/recruiters_list.html
+++ b/backend/apps/admin_ui/templates/recruiters_list.html
@@ -1,5 +1,4 @@
 {% extends "base.html" %}
-{% from "partials/list_toolbar.html" import list_toolbar %}
 {% block title %}Рекрутёры{% endblock %}
 {% block content %}
 <section class="page">
@@ -15,27 +14,6 @@
     </div>
   </header>
 
-  {% call list_toolbar(form_id="recruiter_filters", method="get", mass_actions=[{
-    'label': 'Сбросить',
-    'type': 'button',
-    'variant': 'ghost',
-    'button_type': 'button',
-    'attrs': 'id="flt_reset"'
-  }]) %}
-    <div class="form-field form-field--wide">
-      <label for="flt_query">Поиск</label>
-      <input id="flt_query" type="search" placeholder="Имя, город или chat_id">
-    </div>
-    <div class="form-field form-field--narrow">
-      <label for="flt_state">Статус</label>
-      <select id="flt_state">
-        <option value="">Все</option>
-        <option value="on">Активные</option>
-        <option value="off">Отключённые</option>
-      </select>
-    </div>
-  {% endcall %}
-
   {% if not recruiter_rows %}
     <div class="card glass grain">
       <h3 class="section-title">Пока пусто</h3>
@@ -50,20 +28,15 @@
         {% set r = item.rec %}
         {% set stats = item.stats %}
         {% set active = r.active if r.active is not none else False %}
-        <article class="recruiter-card"
-                 data-name="{{ (r.name or '')|lower }}"
-                 data-tz="{{ (r.tz or 'Europe/Moscow')|lower }}"
-                 data-chat="{{ r.tg_chat_id or '' }}"
-                 data-cities="{{ item.cities_text }}"
-                 data-active="{{ 'on' if active else 'off' }}">
+        <article class="recruiter-card">
           <header class="recruiter-card__header">
-            <div>
+            <div class="recruiter-card__identity">
               <h2 class="recruiter-card__name">{{ r.name }}</h2>
               <div class="meta-list">
                 <span>#{{ r.id }}</span>
-                <span title="Часовой пояс">TZ: {{ r.tz or 'Europe/Moscow' }}</span>
+                <span title="Часовой пояс">{{ r.tz or 'Europe/Moscow' }}</span>
                 {% if r.tg_chat_id %}
-                  <span title="ID чата в Telegram">chat_id: {{ r.tg_chat_id }}</span>
+                  <span title="ID чата в Telegram">chat_id {{ r.tg_chat_id }}</span>
                 {% endif %}
               </div>
             </div>
@@ -72,44 +45,55 @@
             </span>
           </header>
 
-          <div class="section-block">
-            <h3 class="section-title">Нагрузка</h3>
-            <div class="chip-row">
-              <span class="chip chip--success">Свободно <span class="chip__value">{{ stats.free }}</span></span>
-              <span class="chip chip--warning">Ожидают <span class="chip__value">{{ stats.pending }}</span></span>
-              <span class="chip chip--info">Занято <span class="chip__value">{{ stats.booked }}</span></span>
-              <span class="chip">Всего <span class="chip__value">{{ stats.total }}</span></span>
+          <div class="recruiter-card__body">
+            <div class="recruiter-card__section">
+              <h3 class="section-title">Нагрузка</h3>
+              <dl class="recruiter-metrics">
+                <div>
+                  <dt>Свободно</dt>
+                  <dd>{{ stats.free }}</dd>
+                </div>
+                <div>
+                  <dt>Ожидают</dt>
+                  <dd>{{ stats.pending }}</dd>
+                </div>
+                <div>
+                  <dt>Занято</dt>
+                  <dd>{{ stats.booked }}</dd>
+                </div>
+                <div>
+                  <dt>Всего</dt>
+                  <dd>{{ stats.total }}</dd>
+                </div>
+              </dl>
             </div>
-          </div>
 
-          <div class="section-block">
-            <h3 class="section-title">Города</h3>
-            <div class="badge-row">
-              {% if item.cities %}
-                {% for cname, ctz in item.cities %}
-                  <span class="badge" title="{{ ctz }}">{{ cname }}</span>
-                {% endfor %}
+            <div class="recruiter-card__section">
+              <h3 class="section-title">Города</h3>
+              <div class="badge-row">
+                {% if item.cities %}
+                  {% for cname, ctz in item.cities %}
+                    <span class="badge" title="{{ ctz }}">{{ cname }}</span>
+                  {% endfor %}
+                {% else %}
+                  <span class="muted">не назначены</span>
+                {% endif %}
+              </div>
+            </div>
+
+            <div class="recruiter-card__section">
+              <h3 class="section-title">Ближайший свободный слот</h3>
+              {% if item.next_free_local %}
+                <span class="badge">
+                  {{ item.next_free_local }}{% if not item.next_is_future %} · истёк{% endif %}
+                </span>
               {% else %}
-                <span class="muted">не назначены</span>
+                <span class="muted">Нет свободных слотов</span>
               {% endif %}
             </div>
           </div>
 
-          <div class="section-block">
-            <h3 class="section-title">Ближайший свободный слот</h3>
-            {% if item.next_free_local %}
-              <span class="badge">
-                {{ item.next_free_local }}{% if not item.next_is_future %} · истёк{% endif %}
-              </span>
-            {% else %}
-              <span class="muted">Нет свободных слотов</span>
-            {% endif %}
-          </div>
-
           <footer class="recruiter-card__footer">
-            <button class="btn btn-ghost btn--grow" type="button" data-copy="{{ r.tg_chat_id or '' }}" {% if not r.tg_chat_id %}disabled{% endif %}>
-              Скопировать chat_id
-            </button>
             <a class="btn btn-soft btn--grow" href="/recruiters/{{ r.id }}/edit">Редактировать</a>
             <form class="inline-form" method="post" action="/recruiters/{{ r.id }}/delete" onsubmit="return confirm('Удалить рекрутёра {{ r.name }}?');">
               <button class="btn btn-danger btn--grow" type="submit">Удалить</button>
@@ -120,54 +104,4 @@
     </div>
   {% endif %}
 </section>
-
-<script>
-(() => {
-  const $ = (sel, root=document) => root.querySelector(sel);
-  const $$ = (sel, root=document) => Array.from(root.querySelectorAll(sel));
-  const q = $('#flt_query');
-  const state = $('#flt_state');
-  const reset = $('#flt_reset');
-  const cards = $$('#recs_grid .recruiter-card');
-  const norm = v => (v || '').toString().toLowerCase().trim();
-
-  const apply = () => {
-    const query = norm(q && q.value);
-    const st = (state && state.value) || '';
-    cards.forEach(card => {
-      const matchText = !query ||
-        card.dataset.name?.includes(query) ||
-        card.dataset.tz?.includes(query) ||
-        card.dataset.chat?.includes(query) ||
-        card.dataset.cities?.includes(query);
-      const matchState = !st || card.dataset.active === st;
-      card.style.display = (matchText && matchState) ? '' : 'none';
-    });
-  };
-
-  q && q.addEventListener('input', apply);
-  state && state.addEventListener('change', apply);
-  reset && reset.addEventListener('click', () => {
-    if (q) q.value = '';
-    if (state) state.value = '';
-    apply();
-  });
-  apply();
-
-  $$('#recs_grid .recruiter-card button[data-copy]').forEach(btn => {
-    btn.addEventListener('click', async () => {
-      const value = btn.getAttribute('data-copy');
-      if (!value) return;
-      try {
-        await navigator.clipboard.writeText(value);
-        const prev = btn.textContent;
-        btn.textContent = 'Скопировано';
-        setTimeout(() => btn.textContent = prev, 1200);
-      } catch (_) {
-        alert('Не удалось скопировать chat_id');
-      }
-    });
-  });
-})();
-</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- simplify the recruiters list markup by removing toolbar controls and copy chat button
- refresh recruiter cards with cleaner sections, metric layout, and adaptive styling inspired by Apple Tahoe aesthetics
- enhance list styling for better spacing and responsive behaviour across breakpoints

## Testing
- not run (frontend-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68dab405d9c483339518d36a29f117dc