### PR TITLE
Refine city settings editor layout

### DIFF
--- a/backend/apps/admin_ui/static/css/lists.css
+++ b/backend/apps/admin_ui/static/css/lists.css
@@ -617,12 +617,246 @@ button:disabled,
   flex-wrap: wrap;
 }
 
+.info-badge .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: currentColor;
+  opacity: .5;
+}
+
 .save-status.ok {
   color: var(--ok);
 }
 
 .save-status.err {
   color: var(--bad);
+}
+
+.city-sheet {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.city-panel {
+  padding: 18px;
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--glass-stroke);
+  background: linear-gradient(180deg, rgba(255,255,255,.06), rgba(255,255,255,.02));
+  box-shadow: var(--shadow-1);
+}
+
+.city-panel__header {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  margin-bottom: 14px;
+}
+
+.city-panel__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  font-size: 18px;
+  background: rgba(70,87,255,.12);
+  color: var(--primary);
+}
+
+.city-panel__title {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 600;
+}
+
+.city-panel__hint {
+  margin: 2px 0 0;
+  font-size: 13px;
+  color: var(--muted);
+}
+
+.city-panel__body {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.city-panel__body--stacked {
+  gap: 12px;
+}
+
+.city-form__row {
+  display: grid;
+  gap: 12px;
+}
+
+.form-field--compact input {
+  height: 44px;
+}
+
+.city-collapse {
+  border-radius: var(--radius-md);
+  border: 1px solid transparent;
+  background: rgba(255,255,255,.02);
+  transition: border-color .2s ease, background .2s ease;
+}
+
+.city-collapse summary {
+  list-style: none;
+  cursor: pointer;
+  font-weight: 600;
+  font-size: 14px;
+  padding: 12px 14px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.city-collapse summary::-webkit-details-marker {
+  display: none;
+}
+
+.city-collapse summary::after {
+  content: "";
+  margin-left: auto;
+  width: 8px;
+  height: 8px;
+  border-right: 2px solid currentColor;
+  border-bottom: 2px solid currentColor;
+  transform: rotate(-45deg);
+  transition: transform .2s ease;
+  opacity: .5;
+}
+
+.city-collapse[open] {
+  border-color: var(--glass-stroke);
+  background: rgba(255,255,255,.05);
+}
+
+.city-collapse[open] summary::after {
+  transform: rotate(45deg);
+}
+
+.city-collapse__body {
+  padding: 0 14px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.city-panel--stages {
+  background: linear-gradient(180deg, rgba(95,104,255,.12), rgba(36,41,92,.08));
+  border-color: rgba(110,123,255,.32);
+}
+
+.stage-accordion {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.stage-item {
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(110,123,255,.25);
+  background: rgba(16,18,41,.4);
+  overflow: hidden;
+  transition: border-color .2s ease, box-shadow .2s ease;
+}
+
+.stage-item summary {
+  list-style: none;
+  cursor: pointer;
+  padding: 14px 16px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.stage-item summary::-webkit-details-marker {
+  display: none;
+}
+
+.stage-item summary::after {
+  content: "";
+  margin-left: auto;
+  width: 9px;
+  height: 9px;
+  border-right: 2px solid currentColor;
+  border-bottom: 2px solid currentColor;
+  transform: rotate(-45deg);
+  transition: transform .2s ease;
+  opacity: .5;
+}
+
+.stage-item__summary {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  width: 100%;
+}
+
+.stage-item__title {
+  font-weight: 600;
+  font-size: 15px;
+}
+
+.stage-item__preview {
+  font-size: 13px;
+  color: var(--muted);
+}
+
+.stage-item__body {
+  padding: 0 16px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.stage-item textarea {
+  min-height: 120px;
+  resize: vertical;
+}
+
+.stage-item[open] {
+  border-color: var(--primary);
+  box-shadow: var(--shadow-1);
+}
+
+.stage-item[open] summary::after {
+  transform: rotate(45deg);
+}
+
+.stage-item--custom .stage-item__preview {
+  color: var(--primary);
+}
+
+.city-form__footer {
+  margin-top: 18px;
+}
+
+.stage-hint {
+  margin: 4px 0 0;
+  font-size: 13px;
+}
+
+@media (min-width: 760px) {
+  .city-form__row {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 1024px) {
+  .city-sheet {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .city-panel--stages {
+    grid-column: 1 / -1;
+  }
 }
 
 /* Question list */

--- a/backend/apps/admin_ui/templates/cities_list.html
+++ b/backend/apps/admin_ui/templates/cities_list.html
@@ -85,70 +85,117 @@
           </div>
           <div class="city-card__details" hidden>
             <form class="city-form" data-id="{{ c.id }}">
-              <div class="form-field">
-                <label for="owner_{{ c.id }}">Ответственный рекрутёр</label>
-                <select id="owner_{{ c.id }}" name="responsible_id" class="responsible-select">
-                  <option value="">— Не назначен —</option>
-                  {% for r in recruiters %}
-                    <option value="{{ r.id }}" {% if owner_id == r.id %}selected{% endif %}>{{ r.name }}</option>
-                  {% endfor %}
-                </select>
-              </div>
-
-              <div class="form-grid">
-                <div class="form-field">
-                  <label for="crit_{{ c.id }}">Критерии отбора</label>
-                  <textarea id="crit_{{ c.id }}" name="criteria" rows="4" placeholder="Опыт продаж от 6 мес, грамотная речь, готовность к гибридному формату…">{{ criteria }}</textarea>
-                </div>
-                <div class="form-field">
-                  <label for="exp_{{ c.id }}">Ресурсы экспертов</label>
-                  <textarea id="exp_{{ c.id }}" name="experts" rows="4" placeholder="Эксперт A: 10 ч/нед; Эксперт B: 6 ч/нед; Каналы: внутренний реферальный, ярмарки вакансий…">{{ experts }}</textarea>
-                </div>
-              </div>
-
-              <div class="form-grid">
-                <div class="form-field">
-                  <label for="pw_{{ c.id }}">План набора (неделя)</label>
-                  <input id="pw_{{ c.id }}" name="plan_week" type="number" min="0" step="1" value="{{ plan_week }}" placeholder="Например, 12">
-                </div>
-                <div class="form-field">
-                  <label for="pm_{{ c.id }}">План набора (месяц)</label>
-                  <input id="pm_{{ c.id }}" name="plan_month" type="number" min="0" step="1" value="{{ plan_month }}" placeholder="Например, 48">
-                </div>
-              </div>
-
-              <div class="stage-block">
-                <h4>Шаги и шаблоны сообщений</h4>
-                <p class="muted">Настройте тексты, которые бот отправит кандидату на каждом этапе. Оставьте поле пустым, чтобы использовать текст по умолчанию.</p>
-                {% set stages = city_stages.get(c.id, []) %}
-                {% for stage in stages %}
-                  <div class="stage-field" data-stage="{{ stage.key }}">
-                    <label for="stage_{{ stage.key }}_{{ c.id }}">{{ stage.title }}</label>
-                    <textarea
-                      id="stage_{{ stage.key }}_{{ c.id }}"
-                      name="stage__{{ stage.key }}"
-                      data-stage="{{ stage.key }}"
-                      data-default="{{ stage.default|e }}"
-                      rows="6"
-                      placeholder="{{ stage.default|e }}">{{ stage.value }}</textarea>
-                    <div class="stage-controls">
-                      <button type="button" class="btn btn-ghost btn--small stage-default-btn" data-stage="{{ stage.key }}">Вставить текст по умолчанию</button>
-                      <span class="muted">{{ stage.description }}</span>
+              <div class="city-sheet">
+                <section class="city-panel">
+                  <header class="city-panel__header">
+                    <span class="city-panel__icon" aria-hidden="true">🧭</span>
+                    <div>
+                      <h4 class="city-panel__title">Основные параметры</h4>
+                      <p class="city-panel__hint">Кто отвечает за город и какие цели по найму.</p>
+                    </div>
+                  </header>
+                  <div class="city-panel__body">
+                    <div class="form-field">
+                      <label for="owner_{{ c.id }}">Ответственный рекрутёр</label>
+                      <select id="owner_{{ c.id }}" name="responsible_id" class="responsible-select">
+                        <option value="">— Не назначен —</option>
+                        {% for r in recruiters %}
+                          <option value="{{ r.id }}" {% if owner_id == r.id %}selected{% endif %}>{{ r.name }}</option>
+                        {% endfor %}
+                      </select>
+                    </div>
+                    <div class="city-form__row">
+                      <div class="form-field form-field--compact">
+                        <label for="pw_{{ c.id }}">План на неделю</label>
+                        <input id="pw_{{ c.id }}" name="plan_week" type="number" min="0" step="1" value="{{ plan_week }}" placeholder="Например, 12">
+                      </div>
+                      <div class="form-field form-field--compact">
+                        <label for="pm_{{ c.id }}">План на месяц</label>
+                        <input id="pm_{{ c.id }}" name="plan_month" type="number" min="0" step="1" value="{{ plan_month }}" placeholder="Например, 48">
+                      </div>
+                    </div>
+                    <div class="info-badge muted">
+                      <span class="dot"></span>
+                      <span>Контролируйте загрузку команды и динамику выполнения планов.</span>
                     </div>
                   </div>
-                {% endfor %}
-                <p class="muted">
-                  {% raw %}
-                  Доступные переменные: <code>{{candidate_fio}}</code>, <code>{{city_name}}</code>, <code>{{interview_dt_hint}}</code>, <code>{{slot_date_local}}</code>, <code>{{slot_time_local}}</code>, <code>{{slot_datetime_local}}</code>, <code>{{recruiter_name}}</code>, <code>{{address}}</code>.
-                  {% endraw %}
-                </p>
+                </section>
+
+                <section class="city-panel">
+                  <header class="city-panel__header">
+                    <span class="city-panel__icon" aria-hidden="true">📝</span>
+                    <div>
+                      <h4 class="city-panel__title">Профиль города</h4>
+                      <p class="city-panel__hint">Требования к кандидатам и ресурсы экспертов.</p>
+                    </div>
+                  </header>
+                  <div class="city-panel__body city-panel__body--stacked">
+                    <details class="city-collapse" open>
+                      <summary>Критерии отбора</summary>
+                      <div class="city-collapse__body">
+                        <textarea id="crit_{{ c.id }}" name="criteria" rows="4" placeholder="Опыт продаж от 6 мес, грамотная речь, готовность к гибридному формату…">{{ criteria }}</textarea>
+                      </div>
+                    </details>
+                    <details class="city-collapse">
+                      <summary>Ресурсы экспертов</summary>
+                      <div class="city-collapse__body">
+                        <textarea id="exp_{{ c.id }}" name="experts" rows="4" placeholder="Эксперт A: 10 ч/нед; Эксперт B: 6 ч/нед; Каналы: внутренний реферальный, ярмарки вакансий…">{{ experts }}</textarea>
+                      </div>
+                    </details>
+                  </div>
+                </section>
+
+                <section class="city-panel city-panel--stages">
+                  <header class="city-panel__header">
+                    <span class="city-panel__icon" aria-hidden="true">💬</span>
+                    <div>
+                      <h4 class="city-panel__title">Шаги и шаблоны сообщений</h4>
+                      <p class="city-panel__hint">Настройте тексты для кандидатов на каждом этапе воронки.</p>
+                    </div>
+                  </header>
+                  <div class="city-panel__body">
+                    {% set stages = city_stages.get(c.id, []) %}
+                    <div class="stage-accordion">
+                      {% for stage in stages %}
+                        <details class="stage-item" data-stage="{{ stage.key }}">
+                          <summary>
+                            <div class="stage-item__summary">
+                              <span class="stage-item__title">{{ stage.title }}</span>
+                              <span class="stage-item__preview muted">Используется текст по умолчанию</span>
+                            </div>
+                          </summary>
+                          <div class="stage-item__body">
+                            <textarea
+                              id="stage_{{ stage.key }}_{{ c.id }}"
+                              name="stage__{{ stage.key }}"
+                              data-stage="{{ stage.key }}"
+                              data-default="{{ stage.default|e }}"
+                              rows="5"
+                              placeholder="{{ stage.default|e }}">{{ stage.value }}</textarea>
+                            <div class="stage-controls">
+                              <button type="button" class="btn btn-ghost btn--small stage-default-btn" data-stage="{{ stage.key }}">Вставить текст по умолчанию</button>
+                              <span class="muted">{{ stage.description }}</span>
+                            </div>
+                          </div>
+                        </details>
+                      {% endfor %}
+                    </div>
+                    <p class="muted stage-hint">
+                      {% raw %}
+                      Доступные переменные: <code>{{candidate_fio}}</code>, <code>{{city_name}}</code>, <code>{{interview_dt_hint}}</code>, <code>{{slot_date_local}}</code>, <code>{{slot_time_local}}</code>, <code>{{slot_datetime_local}}</code>, <code>{{recruiter_name}}</code>, <code>{{address}}</code>.
+                      {% endraw %}
+                    </p>
+                  </div>
+                </section>
               </div>
 
-              <div class="form-actions">
-                <button type="submit" class="btn btn-primary">Сохранить</button>
-                <button type="button" class="btn btn-ghost btn-cancel">Отмена</button>
-                <span class="badge muted save-status">Сохранено</span>
-              </div>
+              <footer class="city-form__footer">
+                <div class="form-actions">
+                  <button type="submit" class="btn btn-primary">Сохранить</button>
+                  <button type="button" class="btn btn-ghost btn-cancel">Отмена</button>
+                  <span class="badge muted save-status">Сохранено</span>
+                </div>
+              </footer>
             </form>
           </div>
         </article>
@@ -173,6 +220,40 @@
   const totalCount = cards.length;
 
   function norm(s){ return (s||'').toString().trim().toLowerCase(); }
+
+  function truncate(value, limit=120){
+    if (!value) return '';
+    return value.length > limit ? value.slice(0, limit).trimEnd() + '…' : value;
+  }
+
+  function updateStagePreview(details){
+    if (!details) return;
+    const textarea = details.querySelector('textarea[data-stage]');
+    const preview = details.querySelector('.stage-item__preview');
+    if (!textarea || !preview) return;
+    const value = textarea.value.trim();
+    if (value) {
+      preview.textContent = truncate(value);
+      details.classList.add('stage-item--custom');
+    } else {
+      preview.textContent = 'Используется текст по умолчанию';
+      details.classList.remove('stage-item--custom');
+    }
+  }
+
+  function bindStagePreviews(form){
+    if (!form) return;
+    const items = form.querySelectorAll('.stage-item');
+    items.forEach(details => {
+      const textarea = details.querySelector('textarea[data-stage]');
+      if (!textarea) return;
+      if (!textarea.dataset.previewBound) {
+        textarea.addEventListener('input', () => updateStagePreview(details));
+        textarea.dataset.previewBound = '1';
+      }
+      updateStagePreview(details);
+    });
+  }
 
   function closeAll(){
     cards.forEach(card => {
@@ -220,6 +301,7 @@
       if (ta) {
         ta.value = ta.dataset.default || '';
         ta.focus();
+        ta.dispatchEvent(new Event('input', { bubbles: true }));
       }
       e.preventDefault();
       return;
@@ -260,6 +342,7 @@
       if (planMonthField) planMonthField.value = card.dataset.planMonth || '';
       const ownerSelect = form.querySelector('[name="responsible_id"]');
       if (ownerSelect) ownerSelect.value = card.dataset.ownerId || '';
+      bindStagePreviews(form);
     }
 
     card.classList.add('open');


### PR DESCRIPTION
## Summary
- redesign the city settings form into compact panels with collapsible sections and stage accordions
- add stage preview handling and interactive hints for template sections
- refresh styling with accent panels and responsive grid for city configuration cards

## Testing
- python3 -m pytest *(fails: missing aiogram dependency in test suite)*

------
https://chatgpt.com/codex/tasks/task_e_68dab77d3d988333a675a492af8e7c3a