### PR TITLE
Auto-generate template keys during admin creation

### DIFF
--- a/backend/apps/admin_ui/routers/templates.py
+++ b/backend/apps/admin_ui/routers/templates.py
@@ -1,13 +1,12 @@
-from typing import Optional
+from typing import List, Optional
 
-from fastapi import APIRouter, Request
-from fastapi.responses import HTMLResponse, JSONResponse
+from fastapi import APIRouter, Form, Request
+from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
 
 from backend.apps.admin_ui.config import templates as jinja_templates
-from backend.apps.admin_ui.services.templates import (
-    list_templates,
-    update_templates_for_city,
-)
+from backend.apps.admin_ui.services.cities import list_cities
+from backend.apps.admin_ui.services.templates import create_template, list_templates, update_templates_for_city
+from backend.apps.admin_ui.utils import parse_optional_int
 
 router = APIRouter(prefix="/templates", tags=["templates"])
 
@@ -20,6 +19,57 @@ async def templates_list(request: Request):
         "overview": overview,
     }
     return jinja_templates.TemplateResponse("templates_list.html", context)
+
+
+@router.get("/new", response_class=HTMLResponse)
+async def templates_new(request: Request):
+    cities = await list_cities()
+    context = {
+        "request": request,
+        "cities": cities,
+        "errors": [],
+        "form_data": {},
+    }
+    return jinja_templates.TemplateResponse("templates_new.html", context)
+
+
+@router.post("/create")
+async def templates_create(
+    request: Request,
+    text: str = Form(...),
+    city_id: Optional[str] = Form(None),
+    is_global: Optional[str] = Form(None),
+):
+    text_value = (text or "").strip()
+    global_template = bool(is_global)
+    parsed_city = parse_optional_int(city_id)
+    errors: List[str] = []
+
+    if not text_value:
+        errors.append("Введите текст шаблона.")
+
+    if not global_template:
+        if parsed_city is None:
+            errors.append("Выберите город или отметьте шаблон как глобальный.")
+    else:
+        parsed_city = None
+
+    if errors:
+        cities = await list_cities()
+        context = {
+            "request": request,
+            "cities": cities,
+            "errors": errors,
+            "form_data": {
+                "text": text_value,
+                "city_id": parsed_city,
+                "is_global": global_template,
+            },
+        }
+        return jinja_templates.TemplateResponse("templates_new.html", context, status_code=400)
+
+    await create_template(text_value, parsed_city)
+    return RedirectResponse(url="/templates", status_code=303)
 
 
 @router.post("/save")

--- a/backend/apps/admin_ui/templates/templates_new.html
+++ b/backend/apps/admin_ui/templates/templates_new.html
@@ -3,6 +3,7 @@
 {% block title %}Новый шаблон{% endblock %}
 {% block content %}
 {% set has_cities = (cities|length) > 0 %}
+{% set form_data = form_data or {} %}
 {% call forms.shell(
   title="Новый шаблон",
   description="Создайте сообщение для коммуникации с кандидатами.",
@@ -14,10 +15,19 @@
     {"href": "/templates", "text": "Отмена", "variant": "ghost"}
   ]
 ) %}
+  {% if errors %}
+    <div class="alert alert--danger mt-sm">
+      <ul>
+        {% for err in errors %}
+          <li>{{ err }}</li>
+        {% endfor %}
+      </ul>
+    </div>
+  {% endif %}
   {% call forms.section("Назначение") %}
     <div class="form-field__meta">
       <label class="badge" for="is_global">
-        <input id="is_global" name="is_global" type="checkbox" {% if not has_cities %}checked disabled{% endif %}>
+        <input id="is_global" name="is_global" type="checkbox" {% if form_data.is_global or not has_cities %}checked{% endif %}{% if not has_cities %} disabled{% endif %}>
         Глобальный (без города)
       </label>
       <span class="hint">Используется до выбора города кандидатом.</span>
@@ -28,16 +38,15 @@
     {% call forms.field("Город") %}
       <div class="form-shell__grid form-shell__grid--two">
         <select id="city_id" name="city_id" {% if not has_cities %}disabled{% else %}required{% endif %}>
-          <option value="" selected disabled>— выберите город —</option>
+          <option value="" {% if not form_data.city_id %}selected{% endif %} disabled>— выберите город —</option>
           {% for c in cities %}
-            <option value="{{ c.id }}">{{ c.name }} ({{ c.tz or "Europe/Moscow" }})</option>
+            <option value="{{ c.id }}" {% if form_data.city_id == c.id %}selected{% endif %}>{{ c.name }} ({{ c.tz or "Europe/Moscow" }})</option>
           {% endfor %}
         </select>
         <input id="city_filter" type="text" placeholder="Поиск по городам…" {% if not has_cities %}disabled{% endif %}>
       </div>
       <span class="form-field__hint" id="city_hint">Для глобального шаблона город не требуется — включите переключатель «Глобальный».</span>
     {% endcall %}
-    <input id="key" type="hidden" name="key" value="">
   {% endcall %}
 
   {% call forms.section("Содержимое сообщения") %}
@@ -55,7 +64,7 @@
     {% endcall %}
 
     {% call forms.field("Текст", hint="Поддерживаются плейсхолдеры: имя, город, дата/время, контакты.") %}
-      <textarea id="text" name="text" rows="14" required placeholder="Текст сообщения. Поддерживаются переносы строк." class="mt-sm text-mono"></textarea>
+      <textarea id="text" name="text" rows="14" required placeholder="Текст сообщения. Поддерживаются переносы строк." class="mt-sm text-mono">{{ form_data.text or '' }}</textarea>
       <div class="hint mt-sm">Доступные плейсхолдеры (клик вставит в текст):</div>
       <div class="btn-group">
         {% raw %}
@@ -128,7 +137,6 @@ initTemplateEditor({
   placeholderSelector: '[data-role="insert-var"]',
   presets: TEMPLATE_PRESETS,
   presetSelectId: 'preset',
-  keyInputId: 'key',
   isGlobalCheckboxId: 'is_global',
   citySelectId: 'city_id',
   cityFilterId: 'city_filter',


### PR DESCRIPTION
## Summary
- generate new template keys on the server when creating templates so the add form no longer relies on user input
- expose GET/POST routes for creating templates with validation and reuse of the city list
- adjust the template creation form to surface validation errors, persist user input, and drop the hidden key control

## Testing
- pytest *(fails: missing sqlalchemy, starlette, aiogram dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68dab7cd6db88333bd54f3eb54e0f6a9