### PR TITLE
Refresh recruiter cards with shared glass components

### DIFF
--- a/backend/apps/admin_ui/static/css/cards.css
+++ b/backend/apps/admin_ui/static/css/cards.css
@@ -1,0 +1,366 @@
+/* Unified glass card components */
+
+.card-grid {
+  --card-min-width: min(320px, 100%);
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(var(--card-min-width), 1fr));
+  gap: clamp(16px, 3vw, 28px);
+  padding: clamp(4px, 1.5vw, 12px);
+  align-items: stretch;
+}
+
+.glass-card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: clamp(14px, 2vw, 22px);
+  padding: clamp(18px, 2.6vw, 26px);
+  border-radius: clamp(14px, 1.8vw, 20px);
+  border: 1px solid color-mix(in srgb, var(--glass-stroke) 70%, transparent);
+  background:
+    linear-gradient(180deg,
+      color-mix(in srgb, var(--glass-tint) 80%, transparent) 0%,
+      color-mix(in srgb, var(--glass-inner) 18%, transparent) 100%);
+  box-shadow: var(--shadow-2);
+  isolation: isolate;
+  overflow: hidden;
+  transition: transform .28s ease, box-shadow .28s ease, border-color .28s ease, background .28s ease;
+}
+
+.glass-card::before,
+.glass-card::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  border-radius: inherit;
+  transition: opacity .28s ease;
+}
+
+.glass-card::before {
+  background: linear-gradient(120deg, rgba(255,255,255,.16), transparent 55%);
+  mix-blend-mode: screen;
+  opacity: .85;
+}
+
+.glass-card::after {
+  background: radial-gradient(120% 90% at 50% 110%, rgba(0,0,0,.22), transparent 68%);
+  box-shadow: inset 0 1px 0 rgba(255,255,255,.08);
+  opacity: .9;
+}
+
+.glass-card:hover {
+  transform: translateY(-4px);
+  box-shadow: var(--shadow-3);
+}
+
+.glass-card:hover::before {
+  opacity: 1;
+}
+
+.glass-card--summary {
+  gap: 12px;
+  padding: clamp(18px, 3vw, 24px);
+}
+
+.card-surface {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: clamp(14px, 2vw, 18px);
+  border-radius: clamp(12px, 1.6vw, 16px);
+  border: 1px solid color-mix(in srgb, var(--glass-stroke) 55%, transparent);
+  background: linear-gradient(180deg,
+    color-mix(in srgb, var(--glass-tint) 58%, transparent) 0%,
+    color-mix(in srgb, rgba(0,0,0,.35) 16%, transparent) 100%);
+  box-shadow: inset 0 1px 0 rgba(255,255,255,.05);
+}
+
+@supports ((backdrop-filter: blur(10px)) or (-webkit-backdrop-filter: blur(10px))) {
+  .glass-card,
+  .card-surface,
+  .recruiter-card__fold {
+    backdrop-filter: blur(var(--blur)) saturate(var(--sat));
+    -webkit-backdrop-filter: blur(var(--blur)) saturate(var(--sat));
+  }
+}
+
+/* Status pills */
+.status-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 12px;
+  border-radius: 999px;
+  border: 1px solid color-mix(in srgb, var(--glass-stroke) 65%, transparent);
+  background: linear-gradient(180deg,
+    color-mix(in srgb, var(--glass-tint) 70%, transparent) 0%,
+    color-mix(in srgb, rgba(0,0,0,.45) 14%, transparent) 100%);
+  color: color-mix(in srgb, var(--fg) 82%, #fff 18%);
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: .28px;
+  box-shadow: inset 0 1px 0 rgba(255,255,255,.12);
+  transition: color .2s ease, border-color .2s ease, background .2s ease, box-shadow .2s ease;
+}
+
+.status-pill::before {
+  content: "";
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: currentColor;
+  box-shadow: 0 0 0 2px color-mix(in srgb, currentColor 25%, transparent);
+  opacity: .85;
+}
+
+.status-pill__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 12px;
+}
+
+.status-pill[data-tone="success"] {
+  color: color-mix(in srgb, var(--ok) 72%, var(--fg));
+  border-color: color-mix(in srgb, var(--ok) 50%, var(--glass-stroke));
+  background: linear-gradient(180deg,
+    color-mix(in srgb, var(--ok) 24%, rgba(255,255,255,.16)) 0%,
+    color-mix(in srgb, var(--ok) 8%, transparent) 100%);
+  box-shadow: inset 0 1px 0 color-mix(in srgb, var(--ok) 38%, rgba(255,255,255,.35));
+}
+
+.status-pill[data-tone="danger"] {
+  color: color-mix(in srgb, var(--bad) 70%, var(--fg));
+  border-color: color-mix(in srgb, var(--bad) 45%, var(--glass-stroke));
+  background: linear-gradient(180deg,
+    color-mix(in srgb, var(--bad) 22%, rgba(255,255,255,.14)) 0%,
+    color-mix(in srgb, var(--bad) 8%, transparent) 100%);
+  box-shadow: inset 0 1px 0 color-mix(in srgb, var(--bad) 30%, rgba(255,255,255,.35));
+}
+
+.status-pill[data-tone="info"] {
+  color: color-mix(in srgb, var(--accent) 68%, var(--fg));
+  border-color: color-mix(in srgb, var(--accent) 48%, var(--glass-stroke));
+  background: linear-gradient(180deg,
+    color-mix(in srgb, var(--accent) 22%, rgba(255,255,255,.16)) 0%,
+    color-mix(in srgb, var(--accent) 6%, transparent) 100%);
+}
+
+.status-pill[data-tone="muted"],
+.status-pill[data-tone="neutral"] {
+  color: color-mix(in srgb, var(--muted) 85%, var(--fg));
+  border-color: color-mix(in srgb, var(--glass-stroke) 80%, transparent);
+  background: linear-gradient(180deg,
+    color-mix(in srgb, var(--glass-tint) 75%, transparent) 0%,
+    color-mix(in srgb, rgba(0,0,0,.35) 10%, transparent) 100%);
+}
+
+/* Inline helper collections */
+.meta-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  color: color-mix(in srgb, var(--muted) 82%, transparent);
+  font-size: 12px;
+}
+
+.meta-list > * {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.badge-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+/* Recruiter list cards */
+.recruiter-card {
+  min-height: 0;
+}
+
+.recruiter-card__header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 16px;
+}
+
+.recruiter-card__identity {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-width: 0;
+}
+
+.recruiter-card__name {
+  margin: 0;
+  font-size: clamp(20px, 2.2vw, 24px);
+  font-weight: 650;
+  letter-spacing: -0.01em;
+}
+
+.recruiter-card__body {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: clamp(14px, 2vw, 20px);
+}
+
+.recruiter-card__section {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.recruiter-metrics {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 12px;
+  margin: 0;
+}
+
+.recruiter-metrics div {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.recruiter-metrics dt {
+  margin: 0;
+  font-size: 12px;
+  letter-spacing: .3px;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--muted) 88%, transparent);
+}
+
+.recruiter-metrics dd {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 600;
+  color: var(--fg-strong);
+}
+
+.recruiter-card__fold {
+  border-radius: clamp(12px, 1.6vw, 16px);
+  border: 1px solid color-mix(in srgb, var(--glass-stroke) 52%, transparent);
+  background: linear-gradient(180deg,
+    color-mix(in srgb, var(--glass-tint) 60%, transparent) 0%,
+    color-mix(in srgb, rgba(0,0,0,.38) 14%, transparent) 100%);
+  box-shadow: inset 0 1px 0 rgba(255,255,255,.05);
+  overflow: hidden;
+}
+
+.recruiter-card__fold summary {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px 12px;
+  padding: clamp(12px, 2vw, 16px);
+  margin: 0;
+  cursor: pointer;
+  list-style: none;
+  font-weight: 600;
+}
+
+.recruiter-card__fold-head {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px 12px;
+}
+
+.recruiter-card__fold-head .section-title {
+  margin: 0;
+}
+
+.recruiter-card__fold summary::-webkit-details-marker {
+  display: none;
+}
+
+.recruiter-card__fold summary::after {
+  content: "";
+  width: 8px;
+  height: 8px;
+  border-right: 2px solid currentColor;
+  border-bottom: 2px solid currentColor;
+  transform: rotate(-45deg);
+  opacity: .45;
+  transition: transform .2s ease, opacity .2s ease;
+}
+
+.recruiter-card__fold[open] summary::after {
+  transform: rotate(45deg);
+  opacity: .65;
+}
+
+.recruiter-card__fold-body {
+  padding: 0 clamp(12px, 2vw, 18px) clamp(14px, 2vw, 18px);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.recruiter-card__fold-hint {
+  font-size: 12px;
+  color: color-mix(in srgb, var(--muted) 84%, transparent);
+}
+
+.recruiter-card__footer {
+  margin-top: auto;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  justify-content: flex-end;
+}
+
+.recruiter-card__footer .btn {
+  flex: 1 1 160px;
+  justify-content: center;
+}
+
+/* Responsive rules */
+@media (min-width: 600px) {
+  .recruiter-card__fold summary {
+    cursor: default;
+  }
+
+  .recruiter-card__fold summary::after {
+    display: none;
+  }
+}
+
+@media (max-width: 880px) {
+  .card-grid {
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  }
+}
+
+@media (max-width: 600px) {
+  .card-grid {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 16px;
+    padding: 0;
+  }
+
+  .glass-card {
+    padding: 18px;
+    border-radius: 18px;
+  }
+
+  .recruiter-card__body {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .recruiter-card__footer {
+    justify-content: flex-start;
+  }
+
+  .recruiter-card__footer .btn {
+    flex: 1 1 100%;
+  }
+}

--- a/backend/apps/admin_ui/static/css/lists.css
+++ b/backend/apps/admin_ui/static/css/lists.css
@@ -261,8 +261,7 @@ button:disabled,
 }
 
 /* Status badges */
-.status-badge,
-.status-pill {
+.status-badge {
   display: inline-flex;
   align-items: center;
   gap: 6px;
@@ -275,40 +274,28 @@ button:disabled,
   background: rgba(255,255,255,.06);
 }
 
-.status-badge[data-tone="success"],
-.status-pill[data-state="on"] {
+.status-badge[data-tone="success"] {
   color: var(--ok);
   border-color: color-mix(in srgb, var(--ok) 40%, transparent);
   background: color-mix(in srgb, var(--ok) 18%, transparent);
 }
 
-.status-badge[data-tone="warning"],
-.status-pill[data-state="pending"] {
+.status-badge[data-tone="warning"] {
   color: var(--warn);
   border-color: color-mix(in srgb, var(--warn) 40%, transparent);
   background: color-mix(in srgb, var(--warn) 18%, transparent);
 }
 
-.status-badge[data-tone="info"],
-.status-pill[data-state="booked"] {
+.status-badge[data-tone="info"] {
   color: var(--accent);
   border-color: color-mix(in srgb, var(--accent) 40%, transparent);
   background: color-mix(in srgb, var(--accent) 18%, transparent);
 }
 
-.status-badge[data-tone="danger"],
-.status-pill[data-state="off"] {
+.status-badge[data-tone="danger"] {
   color: var(--bad);
   border-color: color-mix(in srgb, var(--bad) 40%, transparent);
   background: color-mix(in srgb, var(--bad) 18%, transparent);
-}
-
-/* Card grids */
-.card-grid {
-  display: grid;
-  gap: 24px;
-  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
-  align-items: stretch;
 }
 
 .stat-grid {
@@ -376,131 +363,6 @@ button:disabled,
   margin: 0;
   font-size: 20px;
   font-weight: 600;
-}
-
-.recruiter-card {
-  display: flex;
-  flex-direction: column;
-  gap: 20px;
-  padding: 24px;
-  border-radius: 20px;
-  border: 1px solid color-mix(in srgb, var(--glass-stroke) 60%, transparent);
-  background: linear-gradient(180deg,
-    color-mix(in srgb, var(--glass-tint) 72%, transparent),
-    color-mix(in srgb, var(--glass-bottom) 45%, transparent));
-  backdrop-filter: blur(22px) saturate(1.12);
-  box-shadow: var(--shadow-2);
-  min-height: 260px;
-  transition: transform .25s ease, box-shadow .25s ease;
-}
-
-.recruiter-card:hover {
-  transform: translateY(-4px);
-  box-shadow: var(--shadow-3);
-}
-
-.recruiter-card__header {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: space-between;
-  gap: 16px;
-  align-items: center;
-}
-
-.recruiter-card__name {
-  margin: 0;
-  font-size: 22px;
-  font-weight: 650;
-}
-
-.meta-list {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 12px;
-  color: color-mix(in srgb, var(--muted) 80%, transparent);
-  font-size: 12px;
-}
-
-.recruiter-card__identity {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-}
-
-.recruiter-card__body {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-  gap: 18px;
-}
-
-.recruiter-card__section {
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-  padding: 16px;
-  border-radius: 16px;
-  border: 1px solid color-mix(in srgb, var(--glass-stroke) 40%, transparent);
-  background: linear-gradient(180deg,
-    color-mix(in srgb, var(--glass-tint) 50%, transparent),
-    color-mix(in srgb, rgba(0,0,0,.20) 12%, transparent));
-}
-
-.recruiter-metrics {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
-  gap: 12px;
-  margin: 0;
-}
-
-.recruiter-metrics div {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-}
-
-.recruiter-metrics dt {
-  margin: 0;
-  font-size: 12px;
-  letter-spacing: .3px;
-  text-transform: uppercase;
-  color: color-mix(in srgb, var(--muted) 90%, transparent);
-}
-
-.recruiter-metrics dd {
-  margin: 0;
-  font-size: 18px;
-  font-weight: 600;
-  color: var(--fg-strong);
-}
-
-.chip-row {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 6px;
-}
-
-.badge-row {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 6px;
-}
-
-.recruiter-card__footer {
-  margin-top: auto;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 12px;
-  justify-content: flex-end;
-}
-
-.section-block {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-}
-
-.section-block .section-title {
-  margin-bottom: 0;
 }
 
 .inline-form {
@@ -1094,11 +956,6 @@ button:disabled,
 
 /* Responsive table conversions */
 @media (max-width: 960px) {
-  .card-grid {
-    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-    gap: 20px;
-  }
-
   .list-toolbar__actions {
     width: 100%;
     justify-content: flex-start;
@@ -1207,28 +1064,6 @@ button:disabled,
     justify-content: flex-start;
   }
 
-  .card-grid {
-    grid-template-columns: minmax(0, 1fr);
-    gap: 18px;
-  }
-
-  .recruiter-card {
-    padding: 20px;
-  }
-
-  .recruiter-card__body {
-    grid-template-columns: minmax(0, 1fr);
-    gap: 16px;
-  }
-
-  .recruiter-card__footer {
-    justify-content: flex-start;
-  }
-
-  .recruiter-card__footer .btn {
-    flex: 1 1 100%;
-  }
-
   .list-toolbar {
     padding: 16px;
   }
@@ -1243,16 +1078,7 @@ button:disabled,
 }
 
 @media (max-width: 480px) {
-  .recruiter-card {
-    padding: 18px;
-    border-radius: 16px;
-  }
-
-  .recruiter-card__name {
-    font-size: 20px;
-  }
-
-  .meta-list {
-    gap: 8px;
+  .list-toolbar {
+    padding: 14px;
   }
 }

--- a/backend/apps/admin_ui/static/css/lists.css
+++ b/backend/apps/admin_ui/static/css/lists.css
@@ -1,3 +1,5 @@
+@import url("/static/css/cards.css");
+
 /* Shared layout primitives for admin lists */
 .page {
   display: flex;

--- a/backend/apps/admin_ui/templates/base.html
+++ b/backend/apps/admin_ui/templates/base.html
@@ -6,6 +6,7 @@
   <title>{% block title %}Админка{% endblock %} · TG Bot Admin</title>
   <link rel="icon" href="/static/favicon.ico">
   <link rel="stylesheet" href="/static/css/lists.css">
+  <link rel="stylesheet" href="/static/css/cards.css">
   <script>
     (function () {
       var storageKey = "tg-admin-theme";

--- a/backend/apps/admin_ui/templates/base.html
+++ b/backend/apps/admin_ui/templates/base.html
@@ -6,7 +6,6 @@
   <title>{% block title %}Админка{% endblock %} · TG Bot Admin</title>
   <link rel="icon" href="/static/favicon.ico">
   <link rel="stylesheet" href="/static/css/lists.css">
-  <link rel="stylesheet" href="/static/css/cards.css">
   <script>
     (function () {
       var storageKey = "tg-admin-theme";

--- a/backend/apps/admin_ui/templates/partials/components.html
+++ b/backend/apps/admin_ui/templates/partials/components.html
@@ -1,0 +1,38 @@
+{% macro status_pill(label, tone='neutral', icon=None, title=None) -%}
+  <span class="status-pill" data-tone="{{ tone }}"{% if title %} title="{{ title }}"{% endif %}>
+    {% if icon %}<span class="status-pill__icon" aria-hidden="true">{{ icon }}</span>{% endif %}
+    <span class="status-pill__label">{{ label }}</span>
+  </span>
+{%- endmacro %}
+
+{% macro meta_list(items=None) -%}
+  <div class="meta-list">
+    {% if items is not none %}
+      {% for item in items %}
+        <span>{{ item }}</span>
+      {% endfor %}
+    {% elif caller is defined %}
+      {{ caller() }}
+    {% endif %}
+  </div>
+{%- endmacro %}
+
+{% macro badge_row(items=None, empty=None) -%}
+  {% if items is not none %}
+    {% set has_items = items | length > 0 %}
+  {% else %}
+    {% set rendered = (caller() if caller is defined else '') %}
+    {% set has_items = rendered.strip() != '' %}
+  {% endif %}
+  <div class="badge-row">
+    {% if items is not none %}
+      {% for item in items %}
+        {{ item }}
+      {% endfor %}
+    {% elif has_items %}
+      {{ rendered | safe }}
+    {% elif empty %}
+      <span class="muted">{{ empty }}</span>
+    {% endif %}
+  </div>
+{%- endmacro %}

--- a/backend/apps/admin_ui/templates/recruiters_list.html
+++ b/backend/apps/admin_ui/templates/recruiters_list.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% from "partials/components.html" import status_pill, meta_list, badge_row %}
 {% block title %}Рекрутёры{% endblock %}
 {% block content %}
 <section class="page">
@@ -15,7 +16,7 @@
   </header>
 
   {% if not recruiter_rows %}
-    <div class="card glass grain">
+    <div class="glass-card glass-card--summary grain">
       <h3 class="section-title">Пока пусто</h3>
       <p class="page-description">Записи отсутствуют. Создайте первого рекрутёра, чтобы начать работу.</p>
       <div class="page-actions">
@@ -28,25 +29,29 @@
         {% set r = item.rec %}
         {% set stats = item.stats %}
         {% set active = r.active if r.active is not none else False %}
-        <article class="recruiter-card">
+        {% set city_count = item.cities|length if item.cities else 0 %}
+        {% if item.next_free_local %}
+          {% set next_slot_label = item.next_free_local ~ (" · истёк" if not item.next_is_future else "") %}
+        {% else %}
+          {% set next_slot_label = None %}
+        {% endif %}
+        <article class="glass-card recruiter-card">
           <header class="recruiter-card__header">
             <div class="recruiter-card__identity">
               <h2 class="recruiter-card__name">{{ r.name }}</h2>
-              <div class="meta-list">
+              {% call meta_list() %}
                 <span>#{{ r.id }}</span>
                 <span title="Часовой пояс">{{ r.tz or 'Europe/Moscow' }}</span>
                 {% if r.tg_chat_id %}
                   <span title="ID чата в Telegram">chat_id {{ r.tg_chat_id }}</span>
                 {% endif %}
-              </div>
+              {% endcall %}
             </div>
-            <span class="status-pill" data-state="{{ 'on' if active else 'off' }}">
-              {{ 'Активен' if active else 'Отключен' }}
-            </span>
+            {{ status_pill('Активен' if active else 'Отключен', tone='success' if active else 'muted') }}
           </header>
 
           <div class="recruiter-card__body">
-            <div class="recruiter-card__section">
+            <section class="card-surface recruiter-card__section recruiter-card__section--metrics">
               <h3 class="section-title">Нагрузка</h3>
               <dl class="recruiter-metrics">
                 <div>
@@ -66,31 +71,46 @@
                   <dd>{{ stats.total }}</dd>
                 </div>
               </dl>
-            </div>
+            </section>
 
-            <div class="recruiter-card__section">
-              <h3 class="section-title">Города</h3>
-              <div class="badge-row">
-                {% if item.cities %}
-                  {% for cname, ctz in item.cities %}
-                    <span class="badge" title="{{ ctz }}">{{ cname }}</span>
-                  {% endfor %}
+            <details class="recruiter-card__fold recruiter-card__section" data-collapsible open>
+              <summary>
+                <div class="recruiter-card__fold-head">
+                  <h3 class="section-title">Города</h3>
+                  {% if city_count %}
+                    {% set city_word = 'город' if city_count % 10 == 1 and city_count % 100 != 11 else ('города' if city_count % 10 in [2, 3, 4] and city_count % 100 not in [12, 13, 14] else 'городов') %}
+                    <span class="recruiter-card__fold-hint">{{ city_count }} {{ city_word }}</span>
+                  {% else %}
+                    <span class="recruiter-card__fold-hint">Нет городов</span>
+                  {% endif %}
+                </div>
+              </summary>
+              <div class="recruiter-card__fold-body">
+                {% call badge_row(empty='не назначены') %}
+                  {% if item.cities %}
+                    {% for cname, ctz in item.cities %}
+                      <span class="badge" title="{{ ctz }}">{{ cname }}</span>
+                    {% endfor %}
+                  {% endif %}
+                {% endcall %}
+              </div>
+            </details>
+
+            <details class="recruiter-card__fold recruiter-card__section" data-collapsible open>
+              <summary>
+                <div class="recruiter-card__fold-head">
+                  <h3 class="section-title">Ближайший свободный слот</h3>
+                  <span class="recruiter-card__fold-hint">{{ next_slot_label if next_slot_label else 'Нет слотов' }}</span>
+                </div>
+              </summary>
+              <div class="recruiter-card__fold-body">
+                {% if next_slot_label %}
+                  <span class="badge">{{ next_slot_label }}</span>
                 {% else %}
-                  <span class="muted">не назначены</span>
+                  <span class="muted">Нет свободных слотов</span>
                 {% endif %}
               </div>
-            </div>
-
-            <div class="recruiter-card__section">
-              <h3 class="section-title">Ближайший свободный слот</h3>
-              {% if item.next_free_local %}
-                <span class="badge">
-                  {{ item.next_free_local }}{% if not item.next_is_future %} · истёк{% endif %}
-                </span>
-              {% else %}
-                <span class="muted">Нет свободных слотов</span>
-              {% endif %}
-            </div>
+            </details>
           </div>
 
           <footer class="recruiter-card__footer">
@@ -104,4 +124,35 @@
     </div>
   {% endif %}
 </section>
+
+{% if recruiter_rows %}
+<script>
+(function () {
+  const BREAKPOINT = 600;
+  const folds = Array.from(document.querySelectorAll('.recruiter-card [data-collapsible]'));
+  if (!folds.length) return;
+
+  let isWide = window.innerWidth >= BREAKPOINT;
+
+  function applyState(forceOpen) {
+    folds.forEach((fold) => {
+      if (forceOpen) {
+        fold.setAttribute('open', '');
+      } else {
+        fold.removeAttribute('open');
+      }
+    });
+  }
+
+  applyState(isWide);
+
+  window.addEventListener('resize', () => {
+    const next = window.innerWidth >= BREAKPOINT;
+    if (next === isWide) return;
+    isWide = next;
+    applyState(isWide);
+  });
+})();
+</script>
+{% endif %}
 {% endblock %}

--- a/backend/apps/admin_ui/templates/slots_list.html
+++ b/backend/apps/admin_ui/templates/slots_list.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% from "partials/list_toolbar.html" import list_toolbar %}
+{% from "partials/components.html" import meta_list %}
 {% block title %}Слоты{% endblock %}
 {% block content %}
 <section class="page">
@@ -164,12 +165,12 @@
             <td class="list-table__details" data-label="">
               <details>
                 <summary>Подробнее</summary>
-                <div class="meta-list">
+                {% call meta_list() %}
                   <span>UTC: {{ fmt_utc(s.start_utc) }}</span>
                   <span>Рекрутёр: {{ s.recruiter.name if s.recruiter else '—' }}</span>
                   {% if s.candidate_fio %}<span>Кандидат: {{ s.candidate_fio }}</span>{% endif %}
                   {% if s.candidate_tz %}<span>TZ кандидата: {{ s.candidate_tz }}</span>{% endif %}
-                </div>
+                {% endcall %}
               </details>
             </td>
           </tr>


### PR DESCRIPTION
## Summary
- add a dedicated `cards.css` module with unified glass card, status pill, and recruiter layout styles while trimming duplicate rules from `lists.css`
- refactor recruiter list cards to use the new grid, macros, and responsive collapsible sections including a small helper script for narrow viewports
- introduce shared Jinja macros for status pills, meta lists, and badge rows and reuse them in recruiter and slot templates while loading the new stylesheet globally

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_68dabda29dac8333b595bef32356e8cf