### PR TITLE
Refresh styling for city management cards

### DIFF
--- a/backend/apps/admin_ui/static/css/lists.css
+++ b/backend/apps/admin_ui/static/css/lists.css
@@ -596,28 +596,77 @@ button:disabled,
 
 /* City list */
 .city-collection {
-  display: flex;
-  flex-direction: column;
-  gap: 14px;
-}
-
-.city-collection {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
-  gap: 20px;
+  gap: 22px;
+  align-items: stretch;
+}
+
+@media (max-width: 720px) {
+  .city-collection {
+    grid-template-columns: minmax(0, 1fr);
+  }
 }
 
 .city-card {
+  position: relative;
   display: flex;
   flex-direction: column;
   gap: 18px;
+  padding: 22px;
+  border-radius: 22px;
+  border: 1px solid color-mix(in srgb, var(--glass-stroke) 65%, transparent);
+  background:
+    linear-gradient(180deg, color-mix(in srgb, var(--glass-tint) 80%, transparent), rgba(6, 10, 32, 0.65)),
+    radial-gradient(120% 140% at 0% 0%, rgba(135, 149, 255, 0.16), transparent 65%);
+  box-shadow: var(--shadow-2);
+  backdrop-filter: blur(calc(var(--blur) * 0.8)) saturate(calc(var(--sat) * 1.05));
+  -webkit-backdrop-filter: blur(calc(var(--blur) * 0.8)) saturate(calc(var(--sat) * 1.05));
+  overflow: hidden;
+  transition: transform .25s ease, box-shadow .25s ease, border-color .25s ease;
+  min-height: 180px;
+}
+
+.city-card::after {
+  content: "";
+  position: absolute;
+  inset: 1px;
+  border-radius: inherit;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  opacity: .6;
+  pointer-events: none;
+  transition: opacity .25s ease;
+}
+
+.city-card:hover {
+  transform: translateY(-4px);
+  box-shadow: var(--shadow-3);
+}
+
+.city-card.open {
+  border-color: color-mix(in srgb, var(--accent) 45%, transparent);
+  box-shadow: var(--shadow-3);
+}
+
+.city-card.open::after {
+  opacity: 1;
 }
 
 .city-card__header {
+  position: relative;
+  z-index: 1;
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: space-between;
-  gap: 12px;
+  gap: 16px;
+}
+
+@media (max-width: 540px) {
+  .city-card__header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 14px;
+  }
 }
 
 .city-card__title {
@@ -626,11 +675,136 @@ button:disabled,
   gap: 6px;
   font-size: 18px;
   font-weight: 600;
+  line-height: 1.2;
+}
+
+.city-card__title .badge {
+  align-self: flex-start;
+  padding: 4px 10px;
+  border-radius: 999px;
+  border: 1px solid color-mix(in srgb, var(--glass-stroke) 60%, transparent);
+  background: rgba(255, 255, 255, 0.06);
+  font-size: 11px;
+  letter-spacing: 0.32px;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--muted) 85%, transparent);
 }
 
 .city-name {
-  font-size: 18px;
-  font-weight: 650;
+  font-size: 19px;
+  font-weight: 660;
+  color: var(--fg-strong);
+  text-shadow: var(--brand-shadow);
+}
+
+.city-card__meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+}
+
+.city-card__meta > * {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  border-radius: 999px;
+  border: 1px solid color-mix(in srgb, var(--glass-stroke) 55%, transparent);
+  background: rgba(10, 14, 26, 0.35);
+  color: color-mix(in srgb, var(--muted) 82%, transparent);
+  line-height: 1.3;
+}
+
+.city-card__meta .badge {
+  font-size: 12px;
+  letter-spacing: 0.28px;
+  font-weight: 600;
+  background: rgba(70, 87, 255, 0.18);
+  border-color: color-mix(in srgb, var(--accent) 50%, transparent);
+  color: color-mix(in srgb, var(--accent) 75%, white 20%);
+}
+
+.city-card__meta .plan-badge {
+  background: rgba(118, 226, 155, 0.18);
+  border-color: color-mix(in srgb, var(--ok) 55%, transparent);
+  color: color-mix(in srgb, var(--ok) 80%, white 18%);
+}
+
+.city-card__meta .city-owner:not(.muted) {
+  background: rgba(70, 87, 255, 0.12);
+  border-color: color-mix(in srgb, var(--accent) 45%, transparent);
+  color: color-mix(in srgb, var(--accent) 78%, white 18%);
+  font-weight: 600;
+}
+
+.city-card__meta .city-owner.muted {
+  opacity: .7;
+}
+
+.city-card__meta .city-tz code {
+  padding: 2px 6px;
+  border-radius: 6px;
+  background: rgba(0, 0, 0, 0.35);
+  color: color-mix(in srgb, var(--accent) 70%, white 20%);
+  font-size: 12px;
+}
+
+.city-card__actions {
+  display: flex;
+  align-items: center;
+  flex: 0 0 auto;
+}
+
+.city-card__actions .btn-edit {
+  padding: 9px 18px;
+  border-radius: 999px;
+  background: linear-gradient(135deg, rgba(70, 87, 255, 0.9), rgba(70, 87, 255, 0.7));
+  border: 1px solid color-mix(in srgb, var(--accent) 55%, transparent);
+  color: #fff;
+  font-weight: 600;
+  letter-spacing: 0.3px;
+  box-shadow: 0 16px 28px rgba(70, 87, 255, 0.25);
+  transition: transform .2s ease, box-shadow .2s ease;
+}
+
+.city-card__actions .btn-edit:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 20px 32px rgba(70, 87, 255, 0.32);
+}
+
+.city-card__actions .btn-edit:focus-visible {
+  outline: 0;
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 35%, transparent), 0 20px 32px rgba(70, 87, 255, 0.32);
+}
+
+.city-card__details {
+  position: relative;
+  margin: -4px;
+  padding: 20px 20px 18px;
+  border-radius: 20px;
+  border: 1px solid color-mix(in srgb, var(--glass-stroke) 70%, transparent);
+  background: linear-gradient(180deg, rgba(16, 18, 41, 0.95), rgba(16, 18, 41, 0.75));
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06);
+  display: grid;
+  gap: 18px;
+}
+
+.city-card.open .city-card__details {
+  animation: city-details-in .24s ease;
+}
+
+@keyframes city-details-in {
+  from {
+    opacity: 0;
+    transform: translateY(-6px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 .template-form {


### PR DESCRIPTION
## Summary
- redesign the city list card layout with glassmorphism, accent chips, and improved hover states
- polish responsive behaviour for the grid and expand animations for the details sheet so the cards feel distinct again

## Testing
- python3 -m pytest *(fails: missing optional dependency `aiogram` required by bot tests)*

------
https://chatgpt.com/codex/tasks/task_e_68dac3e7a1dc8333839257253f0e726e