### PR TITLE
Implement caching for bot templates

### DIFF
--- a/tests/test_bot_templates.py
+++ b/tests/test_bot_templates.py
@@ -1,0 +1,30 @@
+import pytest
+
+from backend.apps.bot import templates
+
+
+@pytest.mark.asyncio
+async def test_tpl_uses_cache(monkeypatch):
+    templates.clear_cache()
+
+    calls = 0
+
+    async def fake_get_template(city_id, key):
+        nonlocal calls
+        calls += 1
+        return "cached-from-db"
+
+    monkeypatch.setattr(templates, "get_template", fake_get_template)
+
+    first = await templates.tpl(42, "greeting")
+    second = await templates.tpl(42, "greeting")
+
+    assert first == "cached-from-db"
+    assert second == "cached-from-db"
+    assert calls == 1
+
+    templates.clear_cache()
+
+    third = await templates.tpl(42, "greeting")
+    assert third == "cached-from-db"
+    assert calls == 2


### PR DESCRIPTION
## Summary
- add an in-memory cache for bot templates keyed by city and template key, plus a clear_cache helper
- reuse cached results in tpl() so repeated lookups avoid the database
- add a pytest covering the caching behaviour and cache reset logic

## Testing
- pytest *(fails: missing optional dependencies such as sqlalchemy, starlette, aiogram)*

------
https://chatgpt.com/codex/tasks/task_e_68dacd3bd8888333b64ca2e48f17c639