### PR TITLE
Ensure city template updates use shared transaction

### DIFF
--- a/backend/apps/admin_ui/routers/templates.py
+++ b/backend/apps/admin_ui/routers/templates.py
@@ -88,5 +88,7 @@ async def templates_save(request: Request):
     if not isinstance(templates_payload, dict):
         templates_payload = {}
 
-    await update_templates_for_city(city_id, templates_payload)
+    error = await update_templates_for_city(city_id, templates_payload)
+    if error:
+        return JSONResponse({"ok": False, "error": error}, status_code=400)
     return JSONResponse({"ok": True})


### PR DESCRIPTION
## Summary
- update city settings to reuse the same transaction when saving templates and recruiter assignments
- allow template updates to reuse an existing async session and surface invalid template key errors
- surface template update errors in the admin API and add a regression test for transaction rollbacks

## Testing
- pytest tests/services/test_templates_and_cities.py

------
https://chatgpt.com/codex/tasks/task_e_68dacd390cd8833397562a6728f2e73d