### PR TITLE
Initialize DB before starting bot polling

### DIFF
--- a/backend/apps/bot/app.py
+++ b/backend/apps/bot/app.py
@@ -8,6 +8,8 @@ from typing import Tuple
 
 from aiogram import Bot, Dispatcher
 
+from backend.core.db import init_models
+
 from .config import BOT_TOKEN, DEFAULT_BOT_PROPERTIES
 from .handlers import register_routers
 from .services import StateManager, configure as configure_services
@@ -44,6 +46,7 @@ async def main() -> None:
     await bot.delete_webhook(drop_pending_updates=True)
     me = await bot.get_me()
     logging.warning("BOOT: using bot id=%s, username=@%s", me.id, me.username)
+    await init_models()
     await dispatcher.start_polling(bot)
 
 

--- a/tests/test_bot_app_smoke.py
+++ b/tests/test_bot_app_smoke.py
@@ -1,12 +1,19 @@
 import pytest
 
-from backend.apps.bot.app import create_application
+pytest.importorskip("aiogram")
+
+from backend.apps.bot import app as bot_app
 from backend.apps.bot.services import StateManager
 
 
 @pytest.mark.asyncio
-async def test_create_application_smoke():
-    bot, dispatcher, state_manager = create_application("123456:ABCDEF")
+async def test_create_application_smoke(monkeypatch):
+    async def dummy_init_models() -> None:
+        return None
+
+    monkeypatch.setattr(bot_app, "init_models", dummy_init_models)
+
+    bot, dispatcher, state_manager = bot_app.create_application("123456:ABCDEF")
 
     assert isinstance(state_manager, StateManager)
     assert dispatcher is not None


### PR DESCRIPTION
## Summary
- ensure the bot initialises the database by running migrations before polling starts
- adjust the bot smoke test to stub `init_models` and skip when aiogram is unavailable

## Testing
- pytest tests/test_bot_app_smoke.py

------
https://chatgpt.com/codex/tasks/task_e_68dad3c306d08333abe9a8d041c3d07b