### PR TITLE
Add bulk slot creation flow

### DIFF
--- a/backend/apps/admin_ui/routers/slots.py
+++ b/backend/apps/admin_ui/routers/slots.py
@@ -7,6 +7,7 @@ from fastapi.responses import HTMLResponse, RedirectResponse
 from backend.apps.admin_ui.config import templates
 from backend.apps.admin_ui.services.recruiters import list_recruiters
 from backend.apps.admin_ui.services.slots import (
+    bulk_create_slots,
     create_slot,
     list_slots,
     recruiters_for_slot_form,
@@ -14,6 +15,21 @@ from backend.apps.admin_ui.services.slots import (
 from backend.apps.admin_ui.utils import norm_status, parse_optional_int, status_filter
 
 router = APIRouter(prefix="/slots", tags=["slots"])
+
+
+def _parse_checkbox(value: Optional[str]) -> bool:
+    return value not in (None, "", "0", "false", "False")
+
+
+def _pop_flash(request: Request) -> Optional[Dict[str, str]]:
+    if hasattr(request, "session"):
+        return request.session.pop("flash", None)
+    return None
+
+
+def _set_flash(request: Request, status: str, message: str) -> None:
+    if hasattr(request, "session"):
+        request.session["flash"] = {"status": status, "message": message}
 
 
 @router.get("", response_class=HTMLResponse)
@@ -39,6 +55,7 @@ async def slots_list(
         "PENDING": status_counter.get("PENDING", 0),
         "BOOKED": status_counter.get("BOOKED", 0),
     }
+    flash = _pop_flash(request)
     context = {
         "request": request,
         "slots": slots,
@@ -49,6 +66,7 @@ async def slots_list(
         "per_page": per_page,
         "recruiter_options": recruiter_options,
         "status_counts": status_counts,
+        "flash": flash,
     }
     return templates.TemplateResponse("slots_list.html", context)
 
@@ -56,7 +74,11 @@ async def slots_list(
 @router.get("/new", response_class=HTMLResponse)
 async def slots_new(request: Request):
     recruiters = await recruiters_for_slot_form()
-    return templates.TemplateResponse("slots_new.html", {"request": request, "recruiters": recruiters})
+    flash = _pop_flash(request)
+    return templates.TemplateResponse(
+        "slots_new.html",
+        {"request": request, "recruiters": recruiters, "flash": flash},
+    )
 
 
 @router.post("/create")
@@ -68,3 +90,40 @@ async def slots_create(
     ok = await create_slot(recruiter_id, date, time)
     redirect = "/slots" if ok else "/slots/new"
     return RedirectResponse(url=redirect, status_code=303)
+
+
+@router.post("/bulk_create")
+async def slots_bulk_create(
+    request: Request,
+    recruiter_id: int = Form(...),
+    start_date: str = Form(...),
+    end_date: str = Form(...),
+    start_time: str = Form(...),
+    end_time: str = Form(...),
+    break_start: str = Form(...),
+    break_end: str = Form(...),
+    step_min: int = Form(...),
+    include_weekends: Optional[str] = Form(default=None),
+    use_break: Optional[str] = Form(default=None),
+):
+    created, error = await bulk_create_slots(
+        recruiter_id=recruiter_id,
+        start_date=start_date,
+        end_date=end_date,
+        start_time=start_time,
+        end_time=end_time,
+        break_start=break_start,
+        break_end=break_end,
+        step_min=step_min,
+        include_weekends=_parse_checkbox(include_weekends),
+        use_break=_parse_checkbox(use_break),
+    )
+
+    if error:
+        _set_flash(request, "error", error)
+    elif created == 0:
+        _set_flash(request, "info", "Новые слоты не созданы — все уже существуют.")
+    else:
+        _set_flash(request, "success", f"Создано {created} слот(ов).")
+
+    return RedirectResponse(url="/slots", status_code=303)

--- a/backend/apps/admin_ui/templates/slots_list.html
+++ b/backend/apps/admin_ui/templates/slots_list.html
@@ -16,6 +16,13 @@
     </div>
   </header>
 
+  {% if flash %}
+    {% set tone = {'success': 'success', 'error': 'danger', 'info': 'info'}.get(flash.status, 'info') %}
+    <div class="surface glass grain alert" data-tone="{{ tone }}" role="alert">
+      <p class="page-description">{{ flash.message }}</p>
+    </div>
+  {% endif %}
+
   <section class="stat-grid" aria-label="Быстрая статистика по слотам">
     <article class="stat-card" data-tone="success">
       <span class="stat-card__label">Свободные</span>

--- a/backend/apps/admin_ui/templates/slots_new.html
+++ b/backend/apps/admin_ui/templates/slots_new.html
@@ -23,6 +23,14 @@
   </div>
 </section>
 
+{% set tone_map = {'success': 'success', 'error': 'danger', 'info': 'info'} %}
+{% if flash %}
+  {% set tone = tone_map.get(flash.status, 'info') %}
+  <div class="surface glass grain alert" data-tone="{{ tone }}" role="alert">
+    <p class="form-shell__section-hint">{{ flash.message }}</p>
+  </div>
+{% endif %}
+
 {% if not recruiters %}
   <div class="surface glass grain alert" role="alert">
     <h2 class="form-shell__section-title">Нет рекрутёров</h2>
@@ -121,8 +129,8 @@
         {% endcall %}
       </div>
       {% call forms.meta() %}
-        {{ forms.switch(id='include_weekends', label='Включать выходные', inline=True) }}
-        {{ forms.switch(id='use_break', label='Учитывать перерыв 12:00–13:00', checked=True, inline=True) }}
+        {{ forms.switch(id='include_weekends', name='include_weekends', label='Включать выходные', inline=True) }}
+        {{ forms.switch(id='use_break', name='use_break', label='Учитывать перерыв 12:00–13:00', checked=True, inline=True) }}
       {% endcall %}
     {% endcall %}
 

--- a/tests/services/test_slots_bulk.py
+++ b/tests/services/test_slots_bulk.py
@@ -1,0 +1,79 @@
+import pytest
+from datetime import date
+
+from sqlalchemy import select
+
+from backend.apps.admin_ui.services.slots import bulk_create_slots
+from backend.apps.admin_ui.utils import recruiter_time_to_utc
+from backend.core.db import async_session
+from backend.domain import models
+
+
+@pytest.mark.asyncio
+async def test_bulk_create_slots_creates_unique_series():
+    async with async_session() as session:
+        recruiter = models.Recruiter(name="Bulk", tz="Europe/Moscow", active=True)
+        session.add(recruiter)
+        await session.commit()
+        await session.refresh(recruiter)
+
+    start = date(2024, 1, 8)
+
+    created, error = await bulk_create_slots(
+        recruiter_id=recruiter.id,
+        start_date=start.isoformat(),
+        end_date=start.isoformat(),
+        start_time="10:00",
+        end_time="11:30",
+        break_start="10:30",
+        break_end="11:00",
+        step_min=30,
+        include_weekends=False,
+        use_break=True,
+    )
+    assert error is None
+    assert created == 2
+
+    created_second, error_second = await bulk_create_slots(
+        recruiter_id=recruiter.id,
+        start_date=start.isoformat(),
+        end_date=start.isoformat(),
+        start_time="10:00",
+        end_time="11:30",
+        break_start="10:30",
+        break_end="11:00",
+        step_min=30,
+        include_weekends=False,
+        use_break=False,
+    )
+    assert error_second is None
+    assert created_second == 1
+
+    created_third, error_third = await bulk_create_slots(
+        recruiter_id=recruiter.id,
+        start_date=start.isoformat(),
+        end_date=start.isoformat(),
+        start_time="10:00",
+        end_time="11:30",
+        break_start="10:30",
+        break_end="11:00",
+        step_min=30,
+        include_weekends=False,
+        use_break=False,
+    )
+    assert error_third is None
+    assert created_third == 0
+
+    async with async_session() as session:
+        stored = set(
+            await session.scalars(
+                select(models.Slot.start_utc).where(models.Slot.recruiter_id == recruiter.id)
+            )
+        )
+
+    expected = {
+        recruiter_time_to_utc(start.isoformat(), "10:00", recruiter.tz),
+        recruiter_time_to_utc(start.isoformat(), "10:30", recruiter.tz),
+        recruiter_time_to_utc(start.isoformat(), "11:00", recruiter.tz),
+    }
+    assert stored == expected


### PR DESCRIPTION
## Summary
- add a bulk slot creation service that generates UTC slots while skipping duplicates
- expose a POST /slots/bulk_create endpoint with flash messaging feedback in list and form views
- surface flash messages in slot templates and add regression test for the bulk creation workflow

## Testing
- pytest tests/services/test_slots_bulk.py *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*


------
https://chatgpt.com/codex/tasks/task_e_68dad3c187288333b4c49823208c0d79