### PR TITLE
Fix missing candidate cities import in bot services

### DIFF
--- a/backend/apps/bot/services.py
+++ b/backend/apps/bot/services.py
@@ -20,7 +20,7 @@ from backend.domain.models import SlotStatus
 from backend.domain.repositories import (
     approve_slot,
     get_city_by_name,
-
+    get_candidate_cities,
     get_active_recruiters_for_city,
     get_free_slots_by_recruiter,
     get_recruiter,


### PR DESCRIPTION
## Summary
- add the missing get_candidate_cities import in the bot services module to prevent runtime errors

## Testing
- pytest tests/test_bot_app_smoke.py

------
https://chatgpt.com/codex/tasks/task_e_68db046ef68c8333b0e1a9b173254fe0