### PR TITLE
Fix missing aliased import in repositories

### DIFF
--- a/backend/domain/repositories.py
+++ b/backend/domain/repositories.py
@@ -2,6 +2,7 @@ from datetime import datetime, timezone
 from typing import Dict, Iterable, List, Optional, Tuple
 
 from sqlalchemy import and_, func, or_, select
+from sqlalchemy.orm import aliased
 
 
 from backend.core.db import async_session


### PR DESCRIPTION
## Summary
- import SQLAlchemy's aliased helper in the repositories module to fix NameError

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db057ce67c8333b10e55707b4d2a5b