### PR TITLE
Support default value retrieval in StateManager

### DIFF
--- a/backend/apps/bot/services.py
+++ b/backend/apps/bot/services.py
@@ -8,7 +8,7 @@ import logging
 import math
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Optional, Tuple, cast
+from typing import Any, Dict, Iterable, List, Optional, Tuple, TypeVar, cast, overload
 from zoneinfo import ZoneInfo
 
 from aiogram import Bot
@@ -64,14 +64,25 @@ for _path in (REPORTS_DIR, TEST1_DIR, UPLOADS_DIR):
     _path.mkdir(parents=True, exist_ok=True)
 
 
+T = TypeVar("T")
+
+
 class StateManager:
     """Simple in-memory state storage for bot flows."""
 
     def __init__(self) -> None:
         self._storage: Dict[int, State] = {}
 
+    @overload
     def get(self, user_id: int) -> Optional[State]:
-        return self._storage.get(user_id)
+        ...
+
+    @overload
+    def get(self, user_id: int, default: T) -> State | T:
+        ...
+
+    def get(self, user_id: int, default: T | None = None) -> State | T | None:
+        return self._storage.get(user_id, default)
 
     def ensure(self, user_id: int) -> State:
         state = self._storage.get(user_id)

--- a/tests/test_bot_app_smoke.py
+++ b/tests/test_bot_app_smoke.py
@@ -19,3 +19,15 @@ async def test_create_application_smoke(monkeypatch):
     assert dispatcher is not None
 
     await bot.session.close()
+
+
+def test_state_manager_get_with_default():
+    manager = StateManager()
+    default_state = {"flow": "intro"}
+
+    assert manager.get(1, default_state) is default_state
+
+    existing_state = {"flow": "interview"}
+    manager.set(1, existing_state)  # type: ignore[arg-type]
+
+    assert manager.get(1, default_state) is existing_state


### PR DESCRIPTION
## Summary
- allow `StateManager.get` to accept an optional default value and propagate it when no state is stored
- add coverage ensuring the default fallback is returned before a state is set

## Testing
- pytest *(fails: missing optional dependencies such as aiogram, sqlalchemy, starlette)*

------
https://chatgpt.com/codex/tasks/task_e_68db08f065e48333b63c925fb24cb895