### PR TITLE
Fix fallback state retrieval when approving or rejecting slots

### DIFF
--- a/backend/apps/bot/services.py
+++ b/backend/apps/bot/services.py
@@ -1078,7 +1078,7 @@ async def handle_approve_slot(callback: CallbackQuery) -> None:
         if getattr(slot, "purpose", "interview") == "intro_day"
         else "approved_msg"
     )
-    state = get_state_manager().get(slot.candidate_tg_id, {})
+    state = get_state_manager().get(slot.candidate_tg_id) or {}
     text = await templates.tpl(
         getattr(slot, "candidate_city_id", None),
         template_key,
@@ -1117,7 +1117,7 @@ async def handle_reject_slot(callback: CallbackQuery) -> None:
     bot = get_bot()
     await bot.send_message(slot.candidate_tg_id, "К сожалению, выбранное время недоступно.")
 
-    st = get_state_manager().get(slot.candidate_tg_id, {})
+    st = get_state_manager().get(slot.candidate_tg_id) or {}
     if st.get("flow") == "intro":
         await show_recruiter_menu(slot.candidate_tg_id)
     else:
@@ -1206,7 +1206,7 @@ async def handle_attendance_no(callback: CallbackQuery) -> None:
         except Exception:
             pass
 
-    st = get_state_manager().get(callback.from_user.id, {})
+    st = get_state_manager().get(callback.from_user.id) or {}
     await bot.send_message(
         callback.from_user.id,
         await templates.tpl(getattr(slot, "candidate_city_id", None), "att_declined"),


### PR DESCRIPTION
## Summary
- avoid passing default dictionaries into the in-memory StateManager to prevent signature mismatches
- ensure approve, reject, and attendance handlers gracefully handle missing state by falling back to empty dicts

## Testing
- pytest tests/test_bot_app_smoke.py -k state_manager_get --maxfail=1 -q

------
https://chatgpt.com/codex/tasks/task_e_68db0a0b0fd883338aaefbdc6d2b4f42