### PR TITLE
Add admin interview outcome flow for second test

### DIFF
--- a/backend/apps/admin_ui/services/__init__.py
+++ b/backend/apps/admin_ui/services/__init__.py
@@ -33,6 +33,7 @@ from .slots import (
     create_slot,
     list_slots,
     recruiters_for_slot_form,
+    set_slot_outcome,
 )
 from .questions import (
     get_test_question_detail,
@@ -69,6 +70,7 @@ __all__ = [
     "list_slots",
     "recruiters_for_slot_form",
     "create_slot",
+    "set_slot_outcome",
     "list_test_questions",
     "get_test_question_detail",
     "update_test_question",

--- a/backend/apps/admin_ui/static/css/lists.css
+++ b/backend/apps/admin_ui/static/css/lists.css
@@ -1793,6 +1793,22 @@ body.sheet-open {
   font-size: 14px;
 }
 
+.slot-outcome__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.slot-outcome__status {
+  margin-top: 4px;
+  font-size: 14px;
+  color: color-mix(in srgb, var(--muted) 80%, var(--fg) 20%);
+}
+
+.slot-outcome__actions .btn.is-active {
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--primary) 40%, transparent 60%);
+}
+
 .slot-person {
   display: flex;
   align-items: center;

--- a/backend/apps/admin_ui/templates/slots_list.html
+++ b/backend/apps/admin_ui/templates/slots_list.html
@@ -147,6 +147,7 @@
               data-candidate="{{ s.candidate_fio or '' }}"
               data-candidate-id="{{ s.candidate_tg_id or '' }}"
               data-candidate-tz="{{ cand_tz or '' }}"
+              data-outcome="{{ s.interview_outcome or '' }}"
               data-can-delete="{{ 1 if st in ['FREE', 'PENDING'] else 0 }}">
             <td data-label="ID">ID {{ s.id }}</td>
             <td data-label="Рекрутёр">
@@ -296,6 +297,24 @@
         </div>
       </section>
 
+      <section class="slot-panel" id="slot_sheet_outcome_section">
+        <div class="slot-panel__header">
+          <span class="slot-panel__icon" aria-hidden="true">✅</span>
+          <div>
+            <h4 class="slot-panel__title">Исход интервью</h4>
+            <p class="slot-panel__hint">Выберите результат встречи</p>
+          </div>
+        </div>
+        <div class="slot-panel__body">
+          <p class="muted" id="slot_sheet_outcome_hint">Доступно после назначения кандидата.</p>
+          <div class="slot-outcome__actions" id="slot_sheet_outcome_actions">
+            <button type="button" class="btn btn-ghost btn--small" data-outcome="passed">Прошёл</button>
+            <button type="button" class="btn btn-ghost btn--small" data-outcome="failed">Не прошёл</button>
+          </div>
+          <p class="slot-outcome__status" id="slot_sheet_outcome_status">Исход не выбран</p>
+        </div>
+      </section>
+
       <section class="slot-panel">
         <div class="slot-panel__header">
           <span class="slot-panel__icon" aria-hidden="true">⏱</span>
@@ -356,6 +375,10 @@
   const slotRecruiter = $('#slot_sheet_recruiter');
   const slotCandidateSection = $('#slot_sheet_candidate_section');
   const slotCandidate = $('#slot_sheet_candidate');
+  const slotOutcomeSection = $('#slot_sheet_outcome_section');
+  const slotOutcomeHint = $('#slot_sheet_outcome_hint');
+  const slotOutcomeActions = $('#slot_sheet_outcome_actions');
+  const slotOutcomeStatus = $('#slot_sheet_outcome_status');
   const slotMeta = $('#slot_sheet_meta');
   const slotDeleteBtn = $('#slot_delete_btn');
   const toastStack = $('#toasts');
@@ -563,6 +586,21 @@
       slotCandidateSection.hidden = true;
     }
     if (slotCandidate) slotCandidate.innerHTML = '';
+    if (slotOutcomeSection){
+      slotOutcomeSection.hidden = true;
+    }
+    if (slotOutcomeHint){
+      slotOutcomeHint.textContent = 'Доступно после назначения кандидата.';
+    }
+    if (slotOutcomeStatus){
+      slotOutcomeStatus.textContent = 'Исход не выбран';
+    }
+    if (slotOutcomeActions){
+      $$('button', slotOutcomeActions).forEach(btn => {
+        btn.disabled = true;
+        btn.classList.remove('is-active');
+      });
+    }
     if (slotMeta) slotMeta.innerHTML = '';
     if (slotDeleteBtn){
       slotDeleteBtn.disabled = true;
@@ -577,6 +615,33 @@
     return 'neutral';
   }
 
+  function normalizeOutcome(raw){
+    const value = (raw || '').toLowerCase();
+    return value === 'passed' || value === 'failed' ? value : '';
+  }
+
+  function setOutcomeButtonsEnabled(enabled){
+    if (!slotOutcomeActions) return;
+    $$('button', slotOutcomeActions).forEach(btn => {
+      btn.disabled = !enabled;
+    });
+  }
+
+  function updateOutcomeUI(outcome){
+    if (!slotOutcomeStatus || !slotOutcomeActions) return;
+    const normalized = normalizeOutcome(outcome);
+    $$('button', slotOutcomeActions).forEach(btn => {
+      btn.classList.toggle('is-active', btn.dataset.outcome === normalized);
+    });
+    if (!normalized){
+      slotOutcomeStatus.textContent = 'Исход не выбран';
+      return;
+    }
+    slotOutcomeStatus.textContent = normalized === 'passed'
+      ? 'Кандидат прошёл интервью'
+      : 'Кандидат не прошёл интервью';
+  }
+
   function hydrateSheet(row){
     const id = row.dataset.id || '—';
     const status = row.dataset.status || '—';
@@ -586,6 +651,7 @@
     const candidateTz = row.dataset.candidateTz || '';
     const candidateId = row.dataset.candidateId || '';
     const duration = parseInt(row.dataset.duration || '0', 10);
+    const outcome = normalizeOutcome(row.dataset.outcome || '');
 
     if (slotTitle) slotTitle.textContent = recruiterName ? `Слот у ${recruiterName}` : `Слот #${id}`;
     if (slotSub) slotSub.textContent = `ID: ${id}`;
@@ -631,6 +697,27 @@
       }
     }
 
+    if (slotOutcomeSection){
+      slotOutcomeSection.hidden = false;
+      const hasCandidate = !!(candidateName && candidateName.trim().length);
+      if (slotOutcomeHint){
+        slotOutcomeHint.textContent = hasCandidate
+          ? 'Отметьте исход. При выборе «Прошёл» бот отправит Тест 2.'
+          : 'Назначьте кандидата, чтобы отметить исход.';
+      }
+      setOutcomeButtonsEnabled(hasCandidate);
+      if (hasCandidate){
+        updateOutcomeUI(outcome);
+      } else if (slotOutcomeStatus){
+        slotOutcomeStatus.textContent = 'Недоступно — кандидат не назначен';
+        if (slotOutcomeActions){
+          $$('button', slotOutcomeActions).forEach(btn => btn.classList.remove('is-active'));
+        }
+      }
+    }
+
+    row.dataset.outcome = outcome;
+
     if (slotMeta){
       const items = [];
       items.push(`Длительность: ${duration || 60} мин`);
@@ -648,6 +735,47 @@
       slotDeleteBtn.dataset.recruiter = recruiterName || '';
     }
 
+  }
+
+  async function submitOutcome(outcome){
+    if (!currentRow) return;
+    if (!slotOutcomeActions) return;
+    const slotId = currentRow.dataset.id;
+    if (!slotId) return;
+    const hasCandidate = !!(currentRow.dataset.candidate && currentRow.dataset.candidate.trim().length);
+    if (!hasCandidate){
+      toast('Назначьте кандидата, чтобы отметить исход.', 'warning');
+      return;
+    }
+
+    setOutcomeButtonsEnabled(false);
+    try {
+      const response = await fetch(`/slots/${slotId}/outcome`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ outcome })
+      });
+      let data = {};
+      try {
+        data = await response.json();
+      } catch (err) {
+        data = {};
+      }
+      if (!response.ok || !data.ok){
+        toast((data && data.message) || 'Не удалось сохранить исход.', 'error');
+        return;
+      }
+      const stored = normalizeOutcome(data.outcome || outcome);
+      currentRow.dataset.outcome = stored;
+      updateOutcomeUI(stored);
+      toast((data && data.message) || 'Исход сохранён.', 'success');
+    } catch (err){
+      console.error(err);
+      toast('Не удалось сохранить исход.', 'error');
+    } finally {
+      const stillHasCandidate = !!(currentRow && currentRow.dataset.candidate && currentRow.dataset.candidate.trim().length);
+      setOutcomeButtonsEnabled(stillHasCandidate);
+    }
   }
 
   function openSlot(row){
@@ -794,6 +922,13 @@
   on(candToggle, 'change', () => {
     persistPreference(storageKeys.candidate, !!candToggle.checked);
     setCandidateColumnVisibility(candToggle.checked);
+  });
+
+  on(slotOutcomeActions, 'click', e => {
+    const btn = e.target.closest('button[data-outcome]');
+    if (!btn || btn.disabled) return;
+    e.preventDefault();
+    submitOutcome(btn.dataset.outcome);
   });
 
   on(slotDeleteBtn, 'click', () => {

--- a/backend/domain/models.py
+++ b/backend/domain/models.py
@@ -97,6 +97,7 @@ class Slot(Base):
     candidate_tg_id: Mapped[Optional[int]] = mapped_column(BigInteger, nullable=True)
     candidate_fio: Mapped[Optional[str]] = mapped_column(String(160), nullable=True)
     candidate_tz: Mapped[Optional[str]] = mapped_column(String(64), nullable=True)
+    interview_outcome: Mapped[Optional[str]] = mapped_column(String(20), nullable=True)
 
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),

--- a/backend/migrations/versions/0003_add_slot_interview_outcome.py
+++ b/backend/migrations/versions/0003_add_slot_interview_outcome.py
@@ -1,0 +1,22 @@
+"""Add interview outcome to slots"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0003_add_slot_interview_outcome"
+down_revision = "0002_seed_defaults"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "slots",
+        sa.Column("interview_outcome", sa.String(length=20), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("slots", "interview_outcome")
+

--- a/tests/services/test_slot_outcome.py
+++ b/tests/services/test_slot_outcome.py
@@ -1,0 +1,97 @@
+from datetime import datetime, timezone
+
+import pytest
+
+pytest.importorskip("sqlalchemy")
+
+from backend.apps.admin_ui.services import slots as slot_services
+from backend.core.db import async_session
+from backend.domain import models
+
+
+@pytest.mark.asyncio
+async def test_set_slot_outcome_triggers_test2(monkeypatch):
+    async with async_session() as session:
+        recruiter = models.Recruiter(name="Outcome", tz="Europe/Moscow", active=True)
+        city = models.City(name="Outcome City", tz="Europe/Moscow", active=True)
+        session.add_all([recruiter, city])
+        await session.commit()
+        await session.refresh(recruiter)
+        await session.refresh(city)
+        city.responsible_recruiter_id = recruiter.id
+        await session.commit()
+        await session.refresh(city)
+        city_id = city.id
+
+        slot = models.Slot(
+            recruiter_id=recruiter.id,
+            city_id=city.id,
+            start_utc=datetime.now(timezone.utc),
+            status=models.SlotStatus.BOOKED,
+            candidate_tg_id=5555,
+            candidate_fio="Иван Тест",
+            candidate_tz="Europe/Moscow",
+            candidate_city_id=city_id,
+        )
+        session.add(slot)
+        await session.commit()
+        await session.refresh(slot)
+        slot_id = slot.id
+
+    calls = {}
+
+    async def fake_send(candidate_id, candidate_tz, candidate_city, candidate_name):
+        calls["args"] = (candidate_id, candidate_tz, candidate_city, candidate_name)
+        return True, None
+
+    monkeypatch.setattr(slot_services, "_send_test2", fake_send)
+
+    ok, message, stored = await slot_services.set_slot_outcome(slot_id, "passed")
+    assert ok is True
+    assert stored == "passed"
+    assert "отправлен" in (message or "").lower()
+    assert calls["args"] == (5555, "Europe/Moscow", city_id, "Иван Тест")
+
+    async with async_session() as session:
+        updated = await session.get(models.Slot, slot_id)
+        assert updated is not None
+        assert updated.interview_outcome == "passed"
+
+
+@pytest.mark.asyncio
+async def test_set_slot_outcome_validates_choice():
+    ok, message, stored = await slot_services.set_slot_outcome(9999, "maybe")
+    assert ok is False
+    assert stored is None
+    assert "Некорректный исход" in (message or "")
+
+
+@pytest.mark.asyncio
+async def test_set_slot_outcome_requires_candidate():
+    async with async_session() as session:
+        recruiter = models.Recruiter(name="Empty", tz="Europe/Moscow", active=True)
+        city = models.City(name="No Candidate", tz="Europe/Moscow", active=True)
+        session.add_all([recruiter, city])
+        await session.commit()
+        await session.refresh(recruiter)
+        await session.refresh(city)
+        city.responsible_recruiter_id = recruiter.id
+        await session.commit()
+        await session.refresh(city)
+        city_id = city.id
+
+        slot = models.Slot(
+            recruiter_id=recruiter.id,
+            city_id=city_id,
+            start_utc=datetime.now(timezone.utc),
+            status=models.SlotStatus.BOOKED,
+        )
+        session.add(slot)
+        await session.commit()
+        await session.refresh(slot)
+        slot_id = slot.id
+
+    ok, message, stored = await slot_services.set_slot_outcome(slot_id, "failed")
+    assert ok is False
+    assert stored is None
+    assert "Слот не привязан к кандидату" in (message or "")


### PR DESCRIPTION
## Summary
- add an interview_outcome column to slots with a migration
- expose a FastAPI endpoint and admin UI controls for recruiters to record outcomes and trigger Test 2
- extend slot services with bot handoff logic and cover it with tests

## Testing
- pytest tests/services/test_slot_outcome.py *(skipped: missing sqlalchemy)*
- pytest tests/services/test_dashboard_and_slots.py *(fails: missing starlette dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68db0dd0aa8c83339cde425cd167d8e4