### PR TITLE
Align slot outcome tests with bot dispatch updates

### DIFF
--- a/backend/domain/models.py
+++ b/backend/domain/models.py
@@ -98,6 +98,8 @@ class Slot(Base):
     candidate_fio: Mapped[Optional[str]] = mapped_column(String(160), nullable=True)
     candidate_tz: Mapped[Optional[str]] = mapped_column(String(64), nullable=True)
     interview_outcome: Mapped[Optional[str]] = mapped_column(String(20), nullable=True)
+    test2_sent_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
+    rejection_sent_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
 
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),

--- a/backend/migrations/versions/0004_add_slot_bot_markers.py
+++ b/backend/migrations/versions/0004_add_slot_bot_markers.py
@@ -1,0 +1,35 @@
+"""Add bot dispatch markers to slots"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from sqlalchemy import inspect
+from sqlalchemy.engine import Connection
+
+revision = "0004_add_slot_bot_markers"
+down_revision = "0003_add_slot_interview_outcome"
+branch_labels = None
+depends_on = None
+
+
+def _column_exists(conn: Connection, table_name: str, column_name: str) -> bool:
+    inspector = inspect(conn)
+    return any(col["name"] == column_name for col in inspector.get_columns(table_name))
+
+
+def upgrade(conn: Connection) -> None:
+    for column in ("test2_sent_at", "rejection_sent_at"):
+        if _column_exists(conn, "slots", column):
+            continue
+        conn.execute(
+            sa.text(
+                f"ALTER TABLE slots ADD COLUMN {column} TIMESTAMP WITH TIME ZONE"
+            )
+        )
+
+
+def downgrade(conn: Connection) -> None:  # pragma: no cover - symmetry with upgrade
+    for column in ("test2_sent_at", "rejection_sent_at"):
+        if not _column_exists(conn, "slots", column):
+            continue
+        conn.execute(sa.text(f"ALTER TABLE slots DROP COLUMN {column}"))


### PR DESCRIPTION
## Summary
- update slot outcome service tests to cover success/reject workflow and dispatch planning
- force admin API tests to initialise a configured bot so headers reflect dispatch status

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68db23a3e40c8333ac4f104dd3135775