### PR TITLE
Improve recruiter form parsing and timezone-safe scheduling

### DIFF
--- a/backend/apps/admin_ui/templates/recruiters_edit.html
+++ b/backend/apps/admin_ui/templates/recruiters_edit.html
@@ -2,6 +2,7 @@
 {% import "partials/form_shell.html" as forms %}
 {% block title %}Редактирование рекрутёра{% endblock %}
 {% block content %}
+{% set form_values = form_data %}
 {% call forms.shell(
   title=recruiter.name,
   description="Измените данные и закреплённые города.",
@@ -16,13 +17,21 @@
     {"href": "/recruiters", "text": "Отмена", "variant": "ghost"}
   ]
 ) %}
+  {% if form_errors %}
+    <p class="form-note" role="alert">
+      <strong>Проверьте форму:</strong><br>
+      {% for err in form_errors %}
+        {{ err }}{% if not loop.last %}<br>{% endif %}
+      {% endfor %}
+    </p>
+  {% endif %}
   {% call forms.section("Основные данные") %}
     <div class="form-grid form-grid--two">
       {% call forms.field("Имя") %}
-        <input type="text" name="name" value="{{ recruiter.name }}" required>
+        <input type="text" name="name" value="{{ form_values.name or recruiter.name }}" required>
       {% endcall %}
       {% call forms.field("Часовой пояс", hint="IANA TZ, например Europe/Moscow") %}
-        <input type="text" name="tz" value="{{ recruiter.tz or 'Europe/Moscow' }}" list="tz-list" required>
+        <input type="text" name="tz" value="{{ form_values.tz or recruiter.tz or 'Europe/Moscow' }}" list="tz-list" required>
         <datalist id="tz-list">
           <option value="Europe/Moscow">
           <option value="Europe/Samara">
@@ -38,10 +47,10 @@
     </div>
     <div class="form-grid form-grid--two">
       {% call forms.field("Ссылка на Телемост", hint="Например: https://telemost.yandex.ru/j/XXXXX") %}
-        <input type="url" name="telemost" value="{{ recruiter.telemost_url or '' }}">
+        <input type="url" name="telemost" value="{{ form_values.telemost if form_values.telemost is not none else recruiter.telemost_url or '' }}">
       {% endcall %}
       {% call forms.field("Telegram chat_id", hint="Можно оставить пустым, если чат ещё не связан") %}
-        <input type="number" name="tg_chat_id" value="{{ recruiter.tg_chat_id or '' }}" min="1" step="1">
+        <input type="number" name="tg_chat_id" value="{{ form_values.tg_chat_id if form_values.tg_chat_id is not none else recruiter.tg_chat_id or '' }}" min="1" step="1">
       {% endcall %}
     </div>
   {% endcall %}
@@ -50,7 +59,7 @@
     <div class="choice-grid" role="group" aria-label="Ответственные города">
       {% for city in cities %}
         <label class="choice-tile">
-          <input type="checkbox" name="cities" value="{{ city.id }}" {% if city.id in selected_ids %}checked{% endif %}>
+          <input type="checkbox" name="cities" value="{{ city.id }}" {% if city.id in form_values.city_ids %}checked{% endif %}>
           <span class="choice-tile__title">{{ city.name }}</span>
           <span class="choice-tile__meta">{{ city.tz }}</span>
         </label>
@@ -59,7 +68,7 @@
   {% endcall %}
 
   {% call forms.field("Статус") %}
-    {{ forms.switch(name='active', value='1', checked=recruiter.active, label='Активен') }}
+    {{ forms.switch(name='active', value='1', checked=form_values.active, label='Активен') }}
   {% endcall %}
 {% endcall %}
 {% endblock %}

--- a/backend/apps/admin_ui/templates/recruiters_new.html
+++ b/backend/apps/admin_ui/templates/recruiters_new.html
@@ -13,13 +13,21 @@
     {"href": "/recruiters", "text": "Отмена", "variant": "ghost"}
   ]
 ) %}
+  {% if form_errors %}
+    <p class="form-note" role="alert">
+      <strong>Проверьте форму:</strong><br>
+      {% for err in form_errors %}
+        {{ err }}{% if not loop.last %}<br>{% endif %}
+      {% endfor %}
+    </p>
+  {% endif %}
   {% call forms.section("Основные данные") %}
     <div class="form-grid form-grid--two">
       {% call forms.field("Имя") %}
-        <input id="name" type="text" name="name" placeholder="Михаил" required>
+        <input id="name" type="text" name="name" placeholder="Михаил" value="{{ form_data.name }}" required>
       {% endcall %}
       {% call forms.field("Часовой пояс", hint="IANA TZ, например Europe/Moscow") %}
-        <input id="tz" type="text" name="tz" value="Europe/Moscow" list="tz-list" required>
+        <input id="tz" type="text" name="tz" value="{{ form_data.tz or 'Europe/Moscow' }}" list="tz-list" required>
         <datalist id="tz-list">
           <option value="Europe/Moscow">
           <option value="Europe/Samara">
@@ -35,10 +43,10 @@
     </div>
     <div class="form-grid form-grid--two">
       {% call forms.field("Ссылка на Телемост", hint="Например: https://telemost.yandex.ru/j/XXXXX") %}
-        <input id="telemost" type="url" name="telemost">
+        <input id="telemost" type="url" name="telemost" value="{{ form_data.telemost }}">
       {% endcall %}
       {% call forms.field("Telegram chat_id", hint="Можно оставить пустым, если чат ещё не связан") %}
-        <input id="tg_chat_id" type="number" name="tg_chat_id" min="1" step="1" placeholder="7588303412">
+        <input id="tg_chat_id" type="number" name="tg_chat_id" min="1" step="1" placeholder="7588303412" value="{{ form_data.tg_chat_id }}">
       {% endcall %}
     </div>
   {% endcall %}
@@ -47,7 +55,7 @@
     <div class="choice-grid" role="group" aria-label="Ответственные города">
       {% for city in cities %}
         <label class="choice-tile">
-          <input type="checkbox" name="cities" value="{{ city.id }}">
+          <input type="checkbox" name="cities" value="{{ city.id }}" {% if city.id in form_data.city_ids %}checked{% endif %}>
           <span class="choice-tile__title">{{ city.name }}</span>
           <span class="choice-tile__meta">{{ city.tz }}</span>
         </label>
@@ -56,7 +64,7 @@
   {% endcall %}
 
   {% call forms.field("Статус") %}
-    {{ forms.switch(id='active', name='active', value='1', checked=True, label='Активен') }}
+    {{ forms.switch(id='active', name='active', value='1', checked=form_data.active, label='Активен') }}
   {% endcall %}
 {% endcall %}
 {% endblock %}

--- a/backend/apps/bot/reminders.py
+++ b/backend/apps/bot/reminders.py
@@ -266,7 +266,7 @@ def create_scheduler(redis_url: Optional[str]) -> AsyncIOScheduler:
         jobstores = {"default": RedisJobStore.from_url(redis_url)}
     else:
         jobstores = {"default": MemoryJobStore()}
-    return AsyncIOScheduler(jobstores=jobstores, timezone="UTC")
+    return AsyncIOScheduler(jobstores=jobstores, timezone=timezone.utc)
 
 
 __all__ = [

--- a/tests/services/test_recruiter_form.py
+++ b/tests/services/test_recruiter_form.py
@@ -1,0 +1,180 @@
+import asyncio
+from typing import Dict, Iterable
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import select
+
+from backend.apps.admin_ui.app import create_app
+from backend.core.db import async_session
+from backend.domain import models
+
+
+def _patch_bot_setup(monkeypatch):
+    from backend.core import settings as settings_module
+
+    class DummyReminderService:
+        def start(self) -> None:
+            return None
+
+        async def shutdown(self) -> None:
+            return None
+
+        async def sync_jobs(self) -> None:
+            return None
+
+        async def schedule_for_slot(self, *_args, **_kwargs):
+            return None
+
+        async def cancel_for_slot(self, *_args, **_kwargs):
+            return None
+
+        def stats(self):
+            return {"total": 0, "reminders": 0, "confirm_prompts": 0}
+
+    class DummyIntegration:
+        def __init__(self, reminder_service):
+            self.reminder_service = reminder_service
+            self.state_manager = None
+            self.bot = None
+            self.bot_service = None
+            self.integration_switch = None
+
+        async def shutdown(self) -> None:
+            await self.reminder_service.shutdown()
+
+    async def fake_setup_bot_state(app):
+        reminder = DummyReminderService()
+        integration = DummyIntegration(reminder)
+        app.state.bot = None
+        app.state.state_manager = None
+        app.state.bot_service = None
+        app.state.bot_integration_switch = None
+        app.state.reminder_service = reminder
+        return integration
+
+    monkeypatch.setenv("ADMIN_USER", "admin")
+    monkeypatch.setenv("ADMIN_PASSWORD", "secret")
+    settings_module.get_settings.cache_clear()
+    monkeypatch.setattr("backend.apps.admin_ui.state.setup_bot_state", fake_setup_bot_state)
+    monkeypatch.setattr("backend.apps.admin_ui.app.setup_bot_state", fake_setup_bot_state)
+
+
+async def _form_request(app, method: str, path: str, *, data: Iterable[tuple[str, str]]):
+    def _call():
+        with TestClient(app) as client:
+            client.auth = ("admin", "secret")
+            payload: Dict[str, object] = {}
+            for key, value in data:
+                if key in payload:
+                    existing = payload[key]
+                    if isinstance(existing, list):
+                        existing.append(value)
+                    else:
+                        payload[key] = [existing, value]
+                else:
+                    payload[key] = value
+            return client.request(method, path, data=payload, follow_redirects=False)
+
+    response = await asyncio.to_thread(_call)
+    return response
+
+
+@pytest.mark.asyncio
+async def test_recruiter_create_form_accepts_optional_fields(monkeypatch):
+    _patch_bot_setup(monkeypatch)
+    app = create_app()
+
+    async with async_session() as session:
+        city = models.City(name="Form City", tz="Europe/Moscow", active=True)
+        session.add(city)
+        await session.commit()
+        await session.refresh(city)
+
+    response = await _form_request(
+        app,
+        "post",
+        "/recruiters/create",
+        data=[
+            ("name", "Анна"),
+            ("tz", "Europe/Berlin"),
+            ("telemost", ""),
+            ("tg_chat_id", ""),
+            ("active", "1"),
+        ],
+    )
+    assert response.status_code == 303
+
+    async with async_session() as session:
+        recruiter = await session.scalar(select(models.Recruiter).where(models.Recruiter.name == "Анна"))
+        assert recruiter is not None
+        assert recruiter.tz == "Europe/Berlin"
+        assert recruiter.telemost_url is None
+        assert recruiter.tg_chat_id is None
+        assert recruiter.active is True
+
+
+@pytest.mark.asyncio
+async def test_recruiter_create_form_handles_invalid_timezone(monkeypatch):
+    _patch_bot_setup(monkeypatch)
+    app = create_app()
+
+    response = await _form_request(
+        app,
+        "post",
+        "/recruiters/create",
+        data=[
+            ("name", "Мария"),
+            ("tz", "Mars/Olympus"),
+            ("telemost", ""),
+            ("tg_chat_id", ""),
+        ],
+    )
+    assert response.status_code == 400
+    body = response.text
+    assert "корректный часовой пояс" in body
+
+    async with async_session() as session:
+        recruiter = await session.scalar(select(models.Recruiter).where(models.Recruiter.name == "Мария"))
+        assert recruiter is None
+
+
+@pytest.mark.asyncio
+async def test_recruiter_create_form_parses_checkbox_and_cities(monkeypatch):
+    _patch_bot_setup(monkeypatch)
+    app = create_app()
+
+    async with async_session() as session:
+        city_a = models.City(name="Alpha", tz="Europe/Moscow", active=True)
+        city_b = models.City(name="Beta", tz="Europe/Samara", active=True)
+        session.add_all([city_a, city_b])
+        await session.commit()
+        await session.refresh(city_a)
+        await session.refresh(city_b)
+        city_a_id = city_a.id
+        city_b_id = city_b.id
+
+    response = await _form_request(
+        app,
+        "post",
+        "/recruiters/create",
+        data=[
+            ("name", "Иван"),
+            ("tz", "Europe/Moscow"),
+            ("telemost", "https://telemost.example.com"),
+            ("tg_chat_id", "123456"),
+            ("cities", str(city_a_id)),
+            ("cities", str(city_b_id)),
+        ],
+    )
+    assert response.status_code == 303
+
+    async with async_session() as session:
+        recruiter = await session.scalar(select(models.Recruiter).where(models.Recruiter.name == "Иван"))
+        assert recruiter is not None
+        assert recruiter.active is False
+        cities = await session.scalars(
+            select(models.City).where(models.City.id.in_([city_a_id, city_b_id]))
+        )
+        linked = {c.responsible_recruiter_id for c in cities}
+        assert linked == {recruiter.id}

--- a/tests/services/test_timezones.py
+++ b/tests/services/test_timezones.py
@@ -1,0 +1,13 @@
+from datetime import datetime, timezone
+
+from backend.apps.admin_ui.utils import recruiter_time_to_utc
+
+
+def test_recruiter_time_to_utc_handles_ambiguous_time():
+    dt_utc = recruiter_time_to_utc("2024-10-27", "02:30", "Europe/Berlin")
+    assert dt_utc == datetime(2024, 10, 27, 0, 30, tzinfo=timezone.utc)
+
+
+def test_recruiter_time_to_utc_rejects_nonexistent_time():
+    dt_utc = recruiter_time_to_utc("2024-03-31", "02:30", "Europe/Berlin")
+    assert dt_utc is None

--- a/tests/test_reminder_service.py
+++ b/tests/test_reminder_service.py
@@ -1,12 +1,20 @@
 import asyncio
+import calendar
 from datetime import datetime, timedelta, timezone
+from zoneinfo import ZoneInfo
 
 import pytest
 
-from backend.apps.bot.reminders import ReminderKind, ReminderService, create_scheduler
+from backend.apps.bot.reminders import (
+    ReminderKind,
+    ReminderService,
+    _ensure_aware,
+    create_scheduler,
+)
 from backend.apps.bot.state_store import build_state_manager
 from backend.core.db import async_session
 from backend.domain import models
+from sqlalchemy import select
 
 
 @pytest.mark.asyncio
@@ -99,3 +107,90 @@ async def test_reminder_service_survives_restart(monkeypatch):
         assert any(job.id.startswith(f"slot:{slot_id}") for job in jobs)
     finally:
         await service2.shutdown()
+
+
+def _next_fall_back_local() -> datetime:
+    tz = ZoneInfo("Europe/Berlin")
+    now_year = datetime.now(timezone.utc).year
+    year = now_year + 1
+    # find last Sunday in October for the chosen year
+    month_matrix = calendar.monthcalendar(year, 10)
+    last_week = month_matrix[-1]
+    if last_week[calendar.SUNDAY] == 0:
+        last_week = month_matrix[-2]
+    day = last_week[calendar.SUNDAY]
+    # 02:30 local time during the transition (ambiguous time)
+    return datetime(year, 10, day, 2, 30, tzinfo=tz)
+
+
+@pytest.mark.asyncio
+async def test_reminder_service_preserves_local_offsets_through_dst():
+    scheduler = create_scheduler(redis_url=None)
+    service = ReminderService(scheduler=scheduler)
+    service.start()
+
+    async with async_session() as session:
+        recruiter = models.Recruiter(name="DST", tz="Europe/Moscow", active=True)
+        city = models.City(name="DST City", tz="Europe/Berlin", active=True)
+        session.add_all([recruiter, city])
+        await session.commit()
+        await session.refresh(recruiter)
+        await session.refresh(city)
+
+        start_local = _next_fall_back_local()
+        start_utc = start_local.astimezone(timezone.utc)
+
+        slot = models.Slot(
+            recruiter_id=recruiter.id,
+            city_id=city.id,
+            start_utc=start_utc,
+            status=models.SlotStatus.BOOKED,
+            candidate_tg_id=4242,
+            candidate_tz="Europe/Berlin",
+        )
+        session.add(slot)
+        await session.commit()
+        await session.refresh(slot)
+        slot_id = slot.id
+
+    try:
+        await service.schedule_for_slot(slot_id)
+        jobs = scheduler.get_jobs()
+        assert jobs, "expected reminder jobs to be scheduled"
+
+        expected_offsets = {
+            ReminderKind.REMIND_24H.value: timedelta(hours=24),
+            ReminderKind.CONFIRM_6H.value: timedelta(hours=6),
+            ReminderKind.REMIND_2H.value: timedelta(hours=2),
+            ReminderKind.REMIND_30M.value: timedelta(minutes=30),
+        }
+        start_local = start_utc.astimezone(ZoneInfo("Europe/Berlin"))
+
+        for job in jobs:
+            kind = job.id.split(":")[-1]
+            if kind not in expected_offsets:
+                continue
+            run = job.next_run_time
+            assert run.tzinfo == timezone.utc
+            run_local = run.astimezone(ZoneInfo("Europe/Berlin"))
+            assert start_local - run_local == expected_offsets[kind]
+
+        async with async_session() as session:
+            rows = await session.execute(
+                select(models.SlotReminderJob).where(models.SlotReminderJob.slot_id == slot_id)
+            )
+            stored_jobs = rows.scalars().all()
+            assert stored_jobs, "expected persisted reminder jobs"
+            job_lookup = {
+                job.id.split(":")[-1]: job
+                for job in jobs
+                if job.id and job.id.startswith(f"slot:{slot_id}:")
+            }
+            for stored in stored_jobs:
+                stored_utc = _ensure_aware(stored.scheduled_at)
+                assert stored_utc.tzinfo == timezone.utc
+                job = job_lookup.get(stored.kind)
+                if job is not None:
+                    assert stored_utc == job.next_run_time
+    finally:
+        await service.shutdown()


### PR DESCRIPTION
## Summary
- parse recruiter forms manually to avoid FastAPI 422s, normalise fields, and render friendly validation errors in templates
- harden timezone helpers and scheduler configuration to operate purely in UTC while handling DST edge cases
- extend reminder service tests for DST transitions and add recruiter form regression coverage

## Testing
- pytest tests/services/test_recruiter_form.py tests/services/test_timezones.py tests/test_reminder_service.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e0f2202c7c8333bfc1252ef3e8c32f