### PR TITLE
Annotate reserve_slot with ReservationResult

### DIFF
--- a/backend/domain/repositories.py
+++ b/backend/domain/repositories.py
@@ -246,7 +246,8 @@ async def reserve_slot(
     purpose: str = "interview",
     expected_recruiter_id: Optional[int] = None,
     expected_city_id: Optional[int] = None,
-) -> Optional[Slot]:
+) -> ReservationResult:
+    """Attempt to reserve the slot and describe the outcome."""
     now_utc = datetime.now(timezone.utc)
 
     city_name: Optional[str] = None


### PR DESCRIPTION
## Summary
- update the reserve_slot repository helper to return ReservationResult explicitly
- document the function contract so callers know to inspect the ReservationResult payload

## Testing
- mypy backend *(fails due to pre-existing typing errors in other modules)*

------
https://chatgpt.com/codex/tasks/task_e_68e28913b800833386d77552aedcd27c