### PR TITLE
Configure bot reminder service lifecycle

### DIFF
--- a/backend/apps/bot/app.py
+++ b/backend/apps/bot/app.py
@@ -14,6 +14,11 @@ from backend.core.settings import get_settings
 from .config import BOT_TOKEN, DEFAULT_BOT_PROPERTIES
 from .handlers import register_routers
 from .services import StateManager, configure as configure_services
+from .reminders import (
+    ReminderService,
+    configure_reminder_service,
+    create_scheduler,
+)
 from .state_store import build_state_manager
 
 __all__ = ["create_application", "create_bot", "create_dispatcher", "main"]
@@ -34,7 +39,9 @@ def create_dispatcher() -> Dispatcher:
     return dispatcher
 
 
-def create_application(token: str | None = None) -> Tuple[Bot, Dispatcher, StateManager]:
+async def create_application(
+    token: str | None = None,
+) -> Tuple[Bot, Dispatcher, StateManager, ReminderService]:
     """Create and configure the bot application components."""
     bot = create_bot(token)
     dispatcher = create_dispatcher()
@@ -43,17 +50,24 @@ def create_application(token: str | None = None) -> Tuple[Bot, Dispatcher, State
         redis_url=getattr(settings, "redis_url", None),
         ttl_seconds=getattr(settings, "state_ttl_seconds", 604800),
     )
+    scheduler = create_scheduler(getattr(settings, "redis_url", None))
+    reminder_service = ReminderService(scheduler=scheduler)
+    configure_reminder_service(reminder_service)
+    await reminder_service.sync_jobs()
     configure_services(bot, state_manager)
-    return bot, dispatcher, state_manager
+    return bot, dispatcher, state_manager, reminder_service
 
 
 async def main() -> None:
-    bot, dispatcher, _ = create_application()
-    await bot.delete_webhook(drop_pending_updates=True)
-    me = await bot.get_me()
-    logging.warning("BOOT: using bot id=%s, username=@%s", me.id, me.username)
-    await init_models()
-    await dispatcher.start_polling(bot)
+    bot, dispatcher, _, reminder_service = await create_application()
+    try:
+        await bot.delete_webhook(drop_pending_updates=True)
+        me = await bot.get_me()
+        logging.warning("BOOT: using bot id=%s, username=@%s", me.id, me.username)
+        await init_models()
+        await dispatcher.start_polling(bot)
+    finally:
+        await reminder_service.shutdown()
 
 
 if __name__ == "__main__":

--- a/tests/test_bot_app_smoke.py
+++ b/tests/test_bot_app_smoke.py
@@ -14,13 +14,16 @@ async def test_create_application_smoke(monkeypatch):
 
     monkeypatch.setattr(bot_app, "init_models", dummy_init_models)
 
-    bot, dispatcher, state_manager = bot_app.create_application("123456:ABCDEF")
+    bot, dispatcher, state_manager, reminder_service = await bot_app.create_application(
+        "123456:ABCDEF"
+    )
 
     assert isinstance(state_manager, StateManager)
     assert dispatcher is not None
 
     await bot.session.close()
     await state_manager.close()
+    await reminder_service.shutdown()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- initialize the reminder scheduler and service when building the bot application and synchronise scheduled jobs
- expose the reminder service from the factory so the bot startup can cleanly shut it down
- adapt the smoke test to await the async factory and close the reminder service after use

## Testing
- pytest tests/test_bot_app_smoke.py
- pytest tests/test_reminder_service.py

------
https://chatgpt.com/codex/tasks/task_e_68e288f17b0c8333a0998066c095f756