### PR TITLE
Add sqladmin dependency for admin API

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,6 +6,7 @@ fastapi==0.112.0
 httpx==0.27.2
 Jinja2==3.1.4
 python-multipart==0.0.9
+sqladmin==0.21.0
 SQLAlchemy==2.0.32
 starlette==0.37.2
 pytest-asyncio==0.23.8


### PR DESCRIPTION
## Summary
- add the sqladmin package to the development requirements so the admin API can import its admin views

## Testing
- pip install -r requirements-dev.txt
- python -c "from backend.apps.admin_api.main import create_app; create_app()"

------
https://chatgpt.com/codex/tasks/task_e_68e2892c39c083338a63b0004903e7f5