### PR TITLE
Handle template update conflicts

### DIFF
--- a/backend/apps/admin_ui/services/templates.py
+++ b/backend/apps/admin_ui/services/templates.py
@@ -201,7 +201,11 @@ async def update_template(tmpl_id: int, *, key: str, text: str, city_id: Optiona
         tmpl.city_id = city_id
         tmpl.key = key.strip()
         tmpl.content = text
-        await session.commit()
+        try:
+            await session.commit()
+        except IntegrityError:
+            await session.rollback()
+            return False
         return True
 
 


### PR DESCRIPTION
## Summary
- roll back and return failure when updating a template violates the unique key constraint
- cover duplicate-key updates with a regression test for the admin template service

## Testing
- pytest tests/services/test_templates_and_cities.py

------
https://chatgpt.com/codex/tasks/task_e_68e28921bb5c83338c8d29d27bf0162d