### PR TITLE
Refine immediate reminders for near-term meetings

### DIFF
--- a/tests/test_reminder_service.py
+++ b/tests/test_reminder_service.py
@@ -41,6 +41,8 @@ async def test_reminder_service_schedules_and_reschedules(monkeypatch):
         jobs = {job.id: job for job in scheduler.get_jobs()}
         assert len(jobs) >= 1
         assert f"slot:{slot_id}:{ReminderKind.REMIND_24H.value}" in jobs
+        assert f"slot:{slot_id}:{ReminderKind.CONFIRM_6H.value}" in jobs
+        assert f"slot:{slot_id}:{ReminderKind.CONFIRM_2H.value}" in jobs
         assert f"slot:{slot_id}:{ReminderKind.REMIND_1H.value}" in jobs
         assert all("remind_30m" not in job_id for job_id in jobs)
 
@@ -101,3 +103,50 @@ async def test_reminder_service_survives_restart(monkeypatch):
         assert any(job.id.startswith(f"slot:{slot_id}") for job in jobs)
     finally:
         await service2.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_reminders_sent_immediately_for_past_targets(monkeypatch):
+    scheduler = create_scheduler(redis_url=None)
+    service = ReminderService(scheduler=scheduler)
+    service.start()
+
+    async with async_session() as session:
+        recruiter = models.Recruiter(name="Immediate", tz="Europe/Moscow", active=True)
+        city = models.City(name="Immediate City", tz="Europe/Moscow", active=True)
+        session.add_all([recruiter, city])
+        await session.commit()
+        await session.refresh(recruiter)
+        await session.refresh(city)
+
+        slot = models.Slot(
+            recruiter_id=recruiter.id,
+            city_id=city.id,
+            start_utc=datetime.now(timezone.utc) + timedelta(minutes=45),
+            status=models.SlotStatus.BOOKED,
+            candidate_tg_id=999,
+            candidate_tz="Europe/Moscow",
+        )
+        session.add(slot)
+        await session.commit()
+        await session.refresh(slot)
+        slot_id = slot.id
+
+    triggered: list[tuple[int, ReminderKind]] = []
+
+    async def fake_execute(slot_id: int, kind: ReminderKind) -> None:
+        triggered.append((slot_id, kind))
+
+    monkeypatch.setattr(service, "_execute_job", fake_execute)
+
+    try:
+        await service.schedule_for_slot(slot_id)
+        kinds = {kind for _slot_id, kind in triggered if _slot_id == slot_id}
+        assert ReminderKind.CONFIRM_2H in kinds
+        assert ReminderKind.REMIND_1H in kinds
+        assert ReminderKind.CONFIRM_6H not in kinds
+        assert ReminderKind.REMIND_24H not in kinds
+        # No future jobs remain because everything should have fired immediately
+        assert scheduler.get_jobs() == []
+    finally:
+        await service.shutdown()


### PR DESCRIPTION
## Summary
- send 2-hour confirmation prompts when scheduling reminders and treat legacy jobs accordingly
- update reminder statistics and scheduling targets to include the new confirmation window
- extend reminder service tests to cover the updated schedule and immediate execution cases
- ensure only the most recent confirmation/reminder fires immediately when a slot is scheduled close to its start time

## Testing
- ADMIN_USER=admin ADMIN_PASSWORD=Nafetomn2001 pytest

------
https://chatgpt.com/codex/tasks/task_e_68e28b9433548333a2e0f40c5a3bfa0d