### PR TITLE
Handle recruiter integrity errors with user-friendly validation

### DIFF
--- a/backend/apps/admin_ui/templates/recruiters_edit.html
+++ b/backend/apps/admin_ui/templates/recruiters_edit.html
@@ -2,6 +2,13 @@
 {% import "partials/form_shell.html" as forms %}
 {% block title %}Редактирование рекрутёра{% endblock %}
 {% block content %}
+{% set form_state = form_data or {} %}
+{% set selected_values = form_state.get('cities', selected_ids) %}
+{% if form_error %}
+  <div class="surface glass grain alert" data-tone="danger" role="alert">
+    {{ form_error }}
+  </div>
+{% endif %}
 {% call forms.shell(
   title=recruiter.name,
   description="Измените данные и закреплённые города.",
@@ -19,10 +26,10 @@
   {% call forms.section("Основные данные") %}
     <div class="form-grid form-grid--two">
       {% call forms.field("Имя") %}
-        <input type="text" name="name" value="{{ recruiter.name }}" required>
+        <input type="text" name="name" value="{{ form_state.get('name', recruiter.name) }}" required>
       {% endcall %}
       {% call forms.field("Регион", hint="Определяет локальное время рекрутёра при создании слотов") %}
-        {% set current_tz = recruiter.tz or 'Europe/Moscow' %}
+        {% set current_tz = form_state.get('tz', recruiter.tz or 'Europe/Moscow') %}
         <select name="tz" required>
           {% for option in tz_options %}
             <option value="{{ option.value }}" {% if option.value == current_tz %}selected{% endif %}>
@@ -34,10 +41,12 @@
     </div>
     <div class="form-grid form-grid--two">
       {% call forms.field("Ссылка на Телемост", hint="Например: https://telemost.yandex.ru/j/XXXXX") %}
-        <input type="url" name="telemost" value="{{ recruiter.telemost_url or '' }}">
+        {% set telemost_value = form_state.get('telemost', recruiter.telemost_url or '') %}
+        <input type="url" name="telemost" value="{{ telemost_value }}">
       {% endcall %}
       {% call forms.field("Telegram chat_id", hint="Можно оставить пустым, если чат ещё не связан") %}
-        <input type="number" name="tg_chat_id" value="{{ recruiter.tg_chat_id or '' }}" min="1" step="1">
+        {% set tg_value = form_state.get('tg_chat_id', recruiter.tg_chat_id or '') %}
+        <input type="number" name="tg_chat_id" value="{{ tg_value }}" min="1" step="1">
       {% endcall %}
     </div>
   {% endcall %}
@@ -46,7 +55,8 @@
     <div class="choice-grid" role="group" aria-label="Ответственные города">
       {% for city in cities %}
         <label class="choice-tile">
-          <input type="checkbox" name="cities" value="{{ city.id }}" {% if city.id in selected_ids %}checked{% endif %}>
+          {% set checked = city.id in selected_values %}
+          <input type="checkbox" name="cities" value="{{ city.id }}" {% if checked %}checked{% endif %}>
           <span class="choice-tile__title">{{ city.name }}</span>
           <span class="choice-tile__meta">{{ city.tz }}</span>
         </label>
@@ -55,7 +65,7 @@
   {% endcall %}
 
   {% call forms.field("Статус") %}
-    {{ forms.switch(name='active', value='1', checked=recruiter.active, label='Активен') }}
+    {{ forms.switch(name='active', value='1', checked=form_state.get('active', recruiter.active), label='Активен') }}
   {% endcall %}
 {% endcall %}
 {% endblock %}

--- a/backend/apps/admin_ui/templates/recruiters_new.html
+++ b/backend/apps/admin_ui/templates/recruiters_new.html
@@ -2,6 +2,13 @@
 {% import "partials/form_shell.html" as forms %}
 {% block title %}Новый рекрутёр{% endblock %}
 {% block content %}
+{% set form_state = form_data or {} %}
+{% set selected_cities = form_state.get('cities', []) %}
+{% if form_error %}
+  <div class="surface glass grain alert" data-tone="danger" role="alert">
+    {{ form_error }}
+  </div>
+{% endif %}
 {% call forms.shell(
   title="Новый рекрутёр",
   description="Создайте запись, чтобы бот мог назначать встречи.",
@@ -16,12 +23,13 @@
   {% call forms.section("Основные данные") %}
     <div class="form-grid form-grid--two">
       {% call forms.field("Имя") %}
-        <input id="name" type="text" name="name" placeholder="Михаил" required>
+        <input id="name" type="text" name="name" value="{{ form_state.get('name', '') }}" placeholder="Михаил" required>
       {% endcall %}
       {% call forms.field("Регион", hint="Определяет локальное время рекрутёра при создании слотов") %}
+        {% set current_tz = form_state.get('tz', 'Europe/Moscow') %}
         <select id="tz" name="tz" required>
           {% for option in tz_options %}
-            <option value="{{ option.value }}" {% if option.value == 'Europe/Moscow' %}selected{% endif %}>
+            <option value="{{ option.value }}" {% if option.value == current_tz %}selected{% endif %}>
               {{ option.label }}
             </option>
           {% endfor %}
@@ -30,10 +38,10 @@
     </div>
     <div class="form-grid form-grid--two">
       {% call forms.field("Ссылка на Телемост", hint="Например: https://telemost.yandex.ru/j/XXXXX") %}
-        <input id="telemost" type="url" name="telemost">
+        <input id="telemost" type="url" name="telemost" value="{{ form_state.get('telemost', '') }}">
       {% endcall %}
       {% call forms.field("Telegram chat_id", hint="Можно оставить пустым, если чат ещё не связан") %}
-        <input id="tg_chat_id" type="number" name="tg_chat_id" min="1" step="1" placeholder="7588303412">
+        <input id="tg_chat_id" type="number" name="tg_chat_id" value="{{ form_state.get('tg_chat_id', '') }}" min="1" step="1" placeholder="7588303412">
       {% endcall %}
     </div>
   {% endcall %}
@@ -42,7 +50,8 @@
     <div class="choice-grid" role="group" aria-label="Ответственные города">
       {% for city in cities %}
         <label class="choice-tile">
-          <input type="checkbox" name="cities" value="{{ city.id }}">
+          {% set checked = city.id in selected_cities %}
+          <input type="checkbox" name="cities" value="{{ city.id }}" {% if checked %}checked{% endif %}>
           <span class="choice-tile__title">{{ city.name }}</span>
           <span class="choice-tile__meta">{{ city.tz }}</span>
         </label>
@@ -51,7 +60,7 @@
   {% endcall %}
 
   {% call forms.field("Статус") %}
-    {{ forms.switch(id='active', name='active', value='1', checked=True, label='Активен') }}
+    {{ forms.switch(id='active', name='active', value='1', checked=form_state.get('active', True), label='Активен') }}
   {% endcall %}
 {% endcall %}
 {% endblock %}

--- a/tests/test_admin_recruiters_ui.py
+++ b/tests/test_admin_recruiters_ui.py
@@ -1,0 +1,134 @@
+import asyncio
+from typing import Any, Dict, Optional
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import select
+
+from backend.apps.admin_ui.app import create_app
+from backend.core.db import async_session
+from backend.domain import models
+
+
+class _DummyIntegration:
+    async def shutdown(self) -> None:
+        return None
+
+
+@pytest.fixture
+def admin_app(monkeypatch) -> Any:
+    async def fake_setup(app) -> _DummyIntegration:
+        app.state.bot = None
+        app.state.state_manager = None
+        app.state.bot_service = None
+        app.state.bot_integration_switch = None
+        app.state.reminder_service = None
+        return _DummyIntegration()
+
+    monkeypatch.setenv("ADMIN_USER", "admin")
+    monkeypatch.setenv("ADMIN_PASSWORD", "admin")
+    from backend.core import settings as settings_module
+
+    settings_module.get_settings.cache_clear()
+    monkeypatch.setattr("backend.apps.admin_ui.state.setup_bot_state", fake_setup)
+    monkeypatch.setattr("backend.apps.admin_ui.app.setup_bot_state", fake_setup)
+    return create_app()
+
+
+async def _async_request(app, method: str, path: str, **kwargs) -> Any:
+    def _call() -> Any:
+        with TestClient(app) as client:
+            client.auth = ("admin", "admin")
+            return client.request(method, path, **kwargs)
+
+    return await asyncio.to_thread(_call)
+
+
+@pytest.mark.asyncio
+async def test_create_recruiter_duplicate_chat_id_returns_validation_message(admin_app) -> None:
+    first_payload = {
+        "name": "Recruiter One",
+        "tz": "Europe/Moscow",
+        "telemost": "",
+        "tg_chat_id": "123456",
+        "active": "1",
+    }
+
+    response_ok = await _async_request(
+        admin_app,
+        "post",
+        "/recruiters/create",
+        data=first_payload,
+        allow_redirects=False,
+    )
+    assert response_ok.status_code == 303
+
+    second_payload = {
+        "name": "Recruiter Duplicate",
+        "tz": "Europe/Moscow",
+        "telemost": "",
+        "tg_chat_id": "123456",
+        "active": "1",
+    }
+
+    response_error = await _async_request(
+        admin_app,
+        "post",
+        "/recruiters/create",
+        data=second_payload,
+        allow_redirects=False,
+    )
+
+    assert response_error.status_code == 400
+    assert "Telegram chat ID уже существует" in response_error.text
+
+    async with async_session() as session:
+        recruiters = (await session.scalars(select(models.Recruiter))).all()
+        assert len(recruiters) == 1
+        assert recruiters[0].tg_chat_id == 123456
+
+
+@pytest.mark.asyncio
+async def test_update_recruiter_duplicate_chat_id_returns_validation_message(admin_app) -> None:
+    async with async_session() as session:
+        recruiter_one = models.Recruiter(
+            name="First",
+            tz="Europe/Moscow",
+            tg_chat_id=999000,
+            active=True,
+        )
+        recruiter_two = models.Recruiter(
+            name="Second",
+            tz="Europe/Moscow",
+            tg_chat_id=888000,
+            active=True,
+        )
+        session.add_all([recruiter_one, recruiter_two])
+        await session.commit()
+        await session.refresh(recruiter_one)
+        await session.refresh(recruiter_two)
+        recruiter_two_id = recruiter_two.id
+
+    update_payload: Dict[str, Optional[str]] = {
+        "name": "Second",
+        "tz": "Europe/Moscow",
+        "telemost": "",
+        "tg_chat_id": "999000",
+        "active": "1",
+    }
+
+    response_error = await _async_request(
+        admin_app,
+        "post",
+        f"/recruiters/{recruiter_two_id}/update",
+        data=update_payload,
+        allow_redirects=False,
+    )
+
+    assert response_error.status_code == 400
+    assert "Telegram chat ID уже существует" in response_error.text
+
+    async with async_session() as session:
+        updated_two = await session.get(models.Recruiter, recruiter_two_id)
+        assert updated_two is not None
+        assert updated_two.tg_chat_id == 888000


### PR DESCRIPTION
## Summary
- wrap recruiter create/update transactions in IntegrityError handling and return structured error payloads
- render recruiter create/edit forms with validation feedback and preserved user input when the service reports errors
- add regression tests covering duplicate Telegram chat IDs to ensure the UI shows a friendly error instead of a 500

## Testing
- pytest tests/test_admin_recruiters_ui.py

------
https://chatgpt.com/codex/tasks/task_e_68e28c94b1a48333ab9650fe7b0c4a33