### PR TITLE
Enable editing templates from admin UI

### DIFF
--- a/backend/apps/admin_ui/routers/templates.py
+++ b/backend/apps/admin_ui/routers/templates.py
@@ -1,11 +1,20 @@
-from typing import List, Optional
+from typing import Dict, List, Optional
+
+from types import SimpleNamespace
 
 from fastapi import APIRouter, Form, Request
 from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
 
 from backend.apps.admin_ui.config import templates as jinja_templates
 from backend.apps.admin_ui.services.cities import list_cities
-from backend.apps.admin_ui.services.templates import create_template, list_templates, update_templates_for_city
+from backend.apps.admin_ui.services.templates import (
+    create_template,
+    delete_template,
+    get_template,
+    list_templates,
+    update_template,
+    update_templates_for_city,
+)
 from backend.apps.admin_ui.utils import parse_optional_int
 
 router = APIRouter(prefix="/templates", tags=["templates"])
@@ -13,10 +22,10 @@ router = APIRouter(prefix="/templates", tags=["templates"])
 
 @router.get("", response_class=HTMLResponse)
 async def templates_list(request: Request):
-    overview = await list_templates()
+    data = await list_templates()
     context = {
         "request": request,
-        "overview": overview,
+        **data,
     }
     return jinja_templates.TemplateResponse("templates_list.html", context)
 
@@ -92,3 +101,136 @@ async def templates_save(request: Request):
     if error:
         return JSONResponse({"ok": False, "error": error}, status_code=400)
     return JSONResponse({"ok": True})
+
+
+def _build_template_payload(
+    *,
+    tmpl_id: int,
+    key: str,
+    text: str,
+    city_id: Optional[int],
+    is_global: bool,
+) -> Dict[str, object]:
+    return {
+        "id": tmpl_id,
+        "key": key,
+        "text_field": text,
+        "city_id": city_id,
+        "is_global": is_global,
+    }
+
+
+@router.get("/{tmpl_id}/edit", response_class=HTMLResponse)
+async def templates_edit(request: Request, tmpl_id: int):
+    tmpl = await get_template(tmpl_id)
+    if not tmpl:
+        return RedirectResponse(url="/templates", status_code=303)
+
+    cities = await list_cities()
+    payload = _build_template_payload(
+        tmpl_id=tmpl.id,
+        key=tmpl.key,
+        text=tmpl.content,
+        city_id=tmpl.city_id,
+        is_global=tmpl.city_id is None,
+    )
+
+    if payload["city_id"] is not None and not any(c.id == payload["city_id"] for c in cities):
+        cities = list(cities) + [
+            SimpleNamespace(
+                id=payload["city_id"],
+                name=f"Город #{payload['city_id']} (удалён)",
+                tz=None,
+            )
+        ]
+
+    context = {
+        "request": request,
+        "tmpl": payload,
+        "cities": cities,
+        "errors": [],
+    }
+    return jinja_templates.TemplateResponse("templates_edit.html", context)
+
+
+@router.post("/{tmpl_id}/update")
+async def templates_update(
+    request: Request,
+    tmpl_id: int,
+    key: str = Form(...),
+    text: str = Form(...),
+    city_id: Optional[str] = Form(None),
+    is_global: Optional[str] = Form(None),
+):
+    tmpl = await get_template(tmpl_id)
+    if not tmpl:
+        return RedirectResponse(url="/templates", status_code=303)
+
+    text_value = (text or "").strip()
+    key_value = (key or "").strip()
+    global_template = bool(is_global)
+    parsed_city = parse_optional_int(city_id)
+    errors: List[str] = []
+
+    if not text_value:
+        errors.append("Введите текст шаблона.")
+
+    if not key_value:
+        errors.append("Введите ключ шаблона.")
+
+    if global_template:
+        parsed_city = None
+    elif parsed_city is None:
+        errors.append("Выберите город или отметьте шаблон как глобальный.")
+
+    payload = _build_template_payload(
+        tmpl_id=tmpl.id,
+        key=key_value,
+        text=text_value,
+        city_id=parsed_city,
+        is_global=global_template,
+    )
+
+    cities = await list_cities()
+    if payload["city_id"] is not None and not any(c.id == payload["city_id"] for c in cities):
+        cities = list(cities) + [
+            SimpleNamespace(
+                id=payload["city_id"],
+                name=f"Город #{payload['city_id']} (удалён)",
+                tz=None,
+            )
+        ]
+
+    if errors:
+        context = {
+            "request": request,
+            "tmpl": payload,
+            "cities": cities,
+            "errors": errors,
+        }
+        return jinja_templates.TemplateResponse("templates_edit.html", context, status_code=400)
+
+    updated = await update_template(
+        tmpl_id,
+        key=key_value,
+        text=text_value,
+        city_id=payload["city_id"],
+    )
+    if not updated:
+        context = {
+            "request": request,
+            "tmpl": payload,
+            "cities": cities,
+            "errors": [
+                "Не удалось сохранить шаблон. Проверьте уникальность ключа и попробуйте ещё раз."
+            ],
+        }
+        return jinja_templates.TemplateResponse("templates_edit.html", context, status_code=400)
+
+    return RedirectResponse(url="/templates", status_code=303)
+
+
+@router.post("/{tmpl_id}/delete")
+async def templates_delete(tmpl_id: int):
+    await delete_template(tmpl_id)
+    return RedirectResponse(url="/templates", status_code=303)

--- a/backend/apps/admin_ui/static/js/modules/template-editor.js
+++ b/backend/apps/admin_ui/static/js/modules/template-editor.js
@@ -236,7 +236,7 @@ export function initTemplateEditor(options = {}) {
     cityFilter.addEventListener('input', filterCities);
   }
 
-  ensureKey(true);
+  ensureKey();
   updateMeta();
   filterCities();
 

--- a/backend/apps/admin_ui/templates/templates_edit.html
+++ b/backend/apps/admin_ui/templates/templates_edit.html
@@ -16,6 +16,15 @@
     {"href": "/templates", "text": "Отмена", "variant": "ghost"}
   ]
 ) %}
+  {% if errors %}
+    <div class="alert alert--danger mt-sm">
+      <ul>
+        {% for err in errors %}
+          <li>{{ err }}</li>
+        {% endfor %}
+      </ul>
+    </div>
+  {% endif %}
   {% call forms.section("Назначение") %}
     {% call forms.field("Глобальный шаблон", hint="Если включено — используется по умолчанию для всех городов") %}
       {{ forms.switch(

--- a/backend/apps/admin_ui/templates/templates_list.html
+++ b/backend/apps/admin_ui/templates/templates_list.html
@@ -9,6 +9,9 @@
         Настройте тексты, которые бот отправляет кандидату на каждом шаге процесса. Пустые поля используют текст по умолчанию.
       </p>
     </div>
+    <div class="page-actions">
+      <a class="btn btn-primary" href="/templates/new">Новый шаблон</a>
+    </div>
   </header>
 
   <div class="card glass grain">
@@ -96,6 +99,53 @@
         <p class="page-description">Добавьте город, чтобы настроить городские сообщения.</p>
       </div>
     {% endfor %}
+  </section>
+
+  <section class="card glass grain template-table-card">
+    <h2 class="section-title">Индивидуальные шаблоны</h2>
+    <p class="section-subtitle">Свободные сообщения, которые можно использовать в интеграциях и ручных рассылках.</p>
+
+    {% if custom_templates %}
+      <div class="list-table-wrapper">
+        <table class="list-table list-table--responsive">
+          <thead>
+            <tr>
+              <th scope="col">ID</th>
+              <th scope="col">Ключ</th>
+              <th scope="col">Назначение</th>
+              <th scope="col" class="is-optional">Фрагмент</th>
+              <th scope="col" class="col-align-end">Действия</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for item in custom_templates %}
+              <tr>
+                <td data-label="ID">#{{ item.id }}</td>
+                <td data-label="Ключ"><code class="text-mono">{{ item.key }}</code></td>
+                <td data-label="Назначение">
+                  {% if item.is_global %}
+                    <span class="badge">Глобальный</span>
+                  {% elif item.city_name %}
+                    <span class="badge">{{ item.city_name }}</span>
+                    {% if item.city_tz %}
+                      <span class="muted">({{ item.city_tz }})</span>
+                    {% endif %}
+                  {% else %}
+                    <span class="muted">Город удалён</span>
+                  {% endif %}
+                </td>
+                <td data-label="Фрагмент" class="is-optional">{{ item.preview }}</td>
+                <td data-label="Действия" class="col-align-end">
+                  <a class="btn btn-soft btn--small" href="/templates/{{ item.id }}/edit">Редактировать</a>
+                </td>
+              </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+    {% else %}
+      <div class="alert mt-sm">Дополнительных шаблонов пока нет. Создайте первый, чтобы использовать его в интеграциях.</div>
+    {% endif %}
   </section>
 </section>
 


### PR DESCRIPTION
## Summary
- add edit, update, and delete handlers for message templates in the admin UI
- extend the templates page with a catalog of custom templates and links to the editor
- surface validation feedback in the editor and keep existing keys when editing

## Testing
- pytest *(fails: missing optional test dependencies such as aiogram, sqlalchemy, pytest_asyncio, apscheduler, redis)*

------
https://chatgpt.com/codex/tasks/task_e_68e28e875b008333b2dd471a539b9db0