### PR TITLE
Redesign admin templates management

### DIFF
--- a/backend/apps/admin_ui/routers/templates.py
+++ b/backend/apps/admin_ui/routers/templates.py
@@ -12,6 +12,7 @@ from backend.apps.admin_ui.services.templates import (
     delete_template,
     get_template,
     list_templates,
+    notify_templates_changed,
     update_template,
     update_templates_for_city,
 )
@@ -78,6 +79,7 @@ async def templates_create(
         return jinja_templates.TemplateResponse("templates_new.html", context, status_code=400)
 
     await create_template(text_value, parsed_city)
+    notify_templates_changed()
     return RedirectResponse(url="/templates", status_code=303)
 
 
@@ -100,6 +102,7 @@ async def templates_save(request: Request):
     error = await update_templates_for_city(city_id, templates_payload)
     if error:
         return JSONResponse({"ok": False, "error": error}, status_code=400)
+    notify_templates_changed()
     return JSONResponse({"ok": True})
 
 
@@ -227,10 +230,12 @@ async def templates_update(
         }
         return jinja_templates.TemplateResponse("templates_edit.html", context, status_code=400)
 
+    notify_templates_changed()
     return RedirectResponse(url="/templates", status_code=303)
 
 
 @router.post("/{tmpl_id}/delete")
 async def templates_delete(tmpl_id: int):
     await delete_template(tmpl_id)
+    notify_templates_changed()
     return RedirectResponse(url="/templates", status_code=303)

--- a/backend/apps/admin_ui/services/templates.py
+++ b/backend/apps/admin_ui/services/templates.py
@@ -20,6 +20,7 @@ __all__ = [
     "templates_overview",
     "update_templates_for_city",
     "list_templates",
+    "notify_templates_changed",
     "generate_template_key",
     "create_template",
     "get_template",
@@ -33,6 +34,20 @@ STAGE_KEYS: List[str] = [stage.key for stage in CITY_TEMPLATE_STAGES]
 
 
 KEY_ALPHABET = string.ascii_lowercase + string.digits
+
+
+def notify_templates_changed() -> None:
+    """Tell the bot runtime to refresh its template cache."""
+
+    try:  # pragma: no cover - optional dependency wiring
+        from backend.apps.bot import templates as bot_templates
+    except Exception:  # pragma: no cover - bot runtime might be unavailable
+        return
+
+    try:
+        bot_templates.clear_cache()
+    except Exception:  # pragma: no cover - guard against runtime issues
+        pass
 
 
 def generate_template_key(prefix: str = "tmpl") -> str:

--- a/backend/apps/admin_ui/static/css/lists.css
+++ b/backend/apps/admin_ui/static/css/lists.css
@@ -2225,11 +2225,191 @@ body.sheet-open {
     padding: 14px;
   }
 
-  .question-card__footer {
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 8px;
-  }
+.question-card__footer {
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 8px;
+}
+}
+
+.template-tabs {
+  display: inline-flex;
+  gap: 8px;
+  padding: 4px;
+  border-radius: 999px;
+  border: 1px solid var(--glass-stroke);
+  background: rgba(255, 255, 255, 0.05);
+  box-shadow: var(--shadow-1);
+}
+
+.template-tab {
+  border: none;
+  background: transparent;
+  color: var(--muted);
+  padding: 8px 18px;
+  border-radius: 999px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.template-tab.is-active {
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.18), rgba(255, 255, 255, 0.06));
+  color: var(--text);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.24);
+}
+
+.template-panel {
+  display: none;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.template-panel.is-active {
+  display: flex;
+}
+
+.template-panel__header {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  justify-content: space-between;
+  align-items: flex-end;
+}
+
+.template-stage {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.template-stage__key {
+  color: var(--muted);
+  font-size: 12px;
+  letter-spacing: 0.24px;
+}
+
+.template-cell {
+  min-width: 240px;
+  vertical-align: top;
+}
+
+.template-preview {
+  padding: 12px;
+  border-radius: var(--radius-md);
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  white-space: pre-wrap;
+  line-height: 1.45;
+  min-height: 96px;
+}
+
+.template-status-line {
+  margin-top: 8px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+}
+
+.template-status {
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--muted);
+}
+
+.template-status--custom {
+  background: color-mix(in srgb, var(--accent) 28%, transparent);
+  color: var(--accent);
+}
+
+.template-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  justify-content: flex-end;
+  align-items: center;
+}
+
+.template-save-indicator {
+  transition: opacity 0.2s ease;
+}
+
+.template-save-indicator.is-ok {
+  background: color-mix(in srgb, var(--ok) 24%, transparent);
+  color: var(--ok);
+}
+
+.template-save-indicator.is-error {
+  background: color-mix(in srgb, var(--bad) 24%, transparent);
+  color: var(--bad);
+}
+
+.template-row.is-editing .template-preview,
+.template-row.is-editing .template-status-line {
+  display: none;
+}
+
+.template-row.is-loading {
+  opacity: 0.6;
+}
+
+.template-editor {
+  width: 100%;
+  resize: vertical;
+  min-height: 120px;
+  padding: 12px;
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  background: rgba(0, 0, 0, 0.18);
+  color: inherit;
+  font: inherit;
+}
+
+.template-editor:focus {
+  outline: 2px solid color-mix(in srgb, var(--accent) 55%, transparent);
+  outline-offset: 2px;
+}
+
+.template-city {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.template-hint {
+  font-size: 13px;
+}
+
+.template-filters {
+  display: flex;
+  gap: 16px;
+  align-items: flex-end;
+  margin-left: auto;
+}
+
+.template-filter {
+  width: 220px;
+  padding: 8px 12px;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--glass-stroke);
+  background: rgba(255, 255, 255, 0.05);
+  color: inherit;
+}
+
+.template-action--danger {
+  color: var(--bad);
+}
+
+.template-action--danger:hover {
+  color: color-mix(in srgb, var(--bad) 82%, white 18%);
+}
+
+.template-panel .list-table-wrapper {
+  margin-top: 4px;
+}
+
+.template-panel .list-table {
+  width: 100%;
 }
 
 @media (max-width: 640px) {
@@ -2252,6 +2432,29 @@ body.sheet-open {
 
   .chip {
     font-size: 11px;
+  }
+
+  .template-tabs {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .template-tab {
+    flex: 1 1 auto;
+    text-align: center;
+  }
+
+  .template-filters {
+    width: 100%;
+    margin-left: 0;
+  }
+
+  .template-filter {
+    width: 100%;
+  }
+
+  .template-cell {
+    min-width: unset;
   }
 }
 

--- a/backend/apps/admin_ui/templates/templates_list.html
+++ b/backend/apps/admin_ui/templates/templates_list.html
@@ -6,7 +6,8 @@
     <div>
       <h1 class="page-title">Шаблоны сообщений</h1>
       <p class="page-description">
-        Настройте тексты, которые бот отправляет кандидату на каждом шаге процесса. Пустые поля используют текст по умолчанию.
+        Управляйте текстами, которые бот отправляет кандидату на каждом шаге процесса. Любые изменения
+        сразу становятся доступными боту и автоматической рассылке.
       </p>
     </div>
     <div class="page-actions">
@@ -32,73 +33,175 @@
     </div>
   </div>
 
-  <section class="card glass tilt" data-tilt data-tilt-max="4" data-tilt-speed="400">
-    <header class="page-header">
+  <nav class="template-tabs" role="tablist" aria-label="Типы шаблонов">
+    <button type="button" class="template-tab is-active" data-tab-target="global">Глобальные шаблоны</button>
+    <button type="button" class="template-tab" data-tab-target="cities">Шаблоны городов</button>
+  </nav>
+
+  <section class="card glass grain template-panel is-active" data-panel="global">
+    <header class="template-panel__header">
       <div>
         <h3 class="card-title">Глобальные шаблоны</h3>
         <p class="page-description">Используются, если для города нет собственного текста.</p>
       </div>
     </header>
-    <form class="template-form" data-city="" autocomplete="off">
-      {% for stage in overview.global.stages %}
-        <div class="stage-field" data-stage="{{ stage.key }}">
-          <div class="stage-field__header">
-            <label for="global_{{ stage.key }}">{{ stage.title }}</label>
-            <button type="button" class="btn btn-soft btn--small stage-default">Стандартный текст</button>
-          </div>
-          <p class="stage-field__description">{{ stage.description }}</p>
-          <textarea
-            id="global_{{ stage.key }}"
-            data-stage="{{ stage.key }}"
-            data-default="{{ stage.default|e }}"
-            rows="6"
-            placeholder="{{ stage.default|e }}">{{ stage.value }}</textarea>
-        </div>
-      {% endfor %}
-      <div class="form-actions">
-        <button type="submit" class="btn btn-primary">Сохранить глобальные</button>
-        <span class="badge muted save-status">Сохранено</span>
-      </div>
-    </form>
+    <div class="list-table-wrapper">
+      <table class="list-table template-table" data-template-table="global">
+        <thead>
+          <tr>
+            <th scope="col">Этап</th>
+            <th scope="col" class="is-optional">Описание</th>
+            <th scope="col">Текст</th>
+            <th scope="col" class="col-align-end">Действия</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for stage in overview.global.stages %}
+            {% set preview_text = stage.value or stage.default %}
+            <tr
+              class="template-row{% if stage.is_custom %} is-custom{% endif %}"
+              data-template-row
+              data-stage="{{ stage.key }}"
+              data-stage-title="{{ stage.title }}"
+              data-city=""
+              data-default="{{ stage.default|e }}"
+              data-current="{{ stage.value|e }}"
+            >
+              <td data-label="Этап">
+                <div class="template-stage">
+                  <strong>{{ stage.title }}</strong>
+                  <span class="template-stage__key"><code class="text-mono">{{ stage.key }}</code></span>
+                </div>
+              </td>
+              <td data-label="Описание" class="template-description is-optional">{{ stage.description }}</td>
+              <td data-label="Текст" class="template-cell">
+                <div class="template-preview" data-role="preview">{{ preview_text or "—" }}</div>
+                <div class="template-status-line">
+                  <span class="badge template-status{% if stage.is_custom %} template-status--custom{% endif %}" data-role="status">
+                    {% if stage.is_custom %}Свой текст{% else %}По умолчанию{% endif %}
+                  </span>
+                  <span class="badge muted template-save-indicator" data-role="save-indicator" hidden>Сохранено</span>
+                </div>
+                <textarea
+                  class="template-editor"
+                  data-role="editor"
+                  data-default="{{ stage.default|e }}"
+                  rows="6"
+                  hidden
+                >{{ stage.value or "" }}</textarea>
+              </td>
+              <td data-label="Действия" class="col-align-end">
+                <div class="template-actions" data-role="view-actions">
+                  <button type="button" class="btn btn-soft btn--small" data-action="edit">Редактировать</button>
+                  <button type="button" class="btn btn-ghost btn--small template-action--danger" data-action="clear">Удалить</button>
+                </div>
+                <div class="template-actions" data-role="edit-actions" hidden>
+                  <button type="button" class="btn btn-primary btn--small" data-action="save">Сохранить</button>
+                  <button type="button" class="btn btn-soft btn--small" data-action="cancel">Отмена</button>
+                </div>
+              </td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+    <footer class="template-hint muted">Удаление очищает текст и возвращает стандартный шаблон.</footer>
   </section>
 
-  <section class="city-collection">
-    {% for entry in overview.cities %}
-      <article class="card glass grain city-card" data-city="{{ entry.city.id }}">
-        <header class="city-card__header">
-          <div class="city-card__title">
-            <span class="city-name">{{ entry.city.name }}</span>
-            <span class="badge" title="Часовой пояс">{{ entry.city.tz or "Europe/Moscow" }}</span>
-          </div>
-        </header>
-        <form class="template-form" data-city="{{ entry.city.id }}" autocomplete="off">
-          {% for stage in entry.stages %}
-            <div class="stage-field" data-stage="{{ stage.key }}">
-              <div class="stage-field__header">
-                <label for="stage_{{ entry.city.id }}_{{ stage.key }}">{{ stage.title }}</label>
-                <button type="button" class="btn btn-soft btn--small stage-default">Стандартный текст</button>
-              </div>
-              <p class="stage-field__description">{{ stage.description }}</p>
-              <textarea
-                id="stage_{{ entry.city.id }}_{{ stage.key }}"
-                data-stage="{{ stage.key }}"
-                data-default="{{ stage.default|e }}"
-                rows="6"
-                placeholder="{{ stage.default|e }}">{{ stage.value }}</textarea>
-            </div>
-          {% endfor %}
-          <div class="form-actions">
-            <button type="submit" class="btn btn-primary">Сохранить</button>
-            <span class="badge muted save-status">Сохранено</span>
-          </div>
-        </form>
-      </article>
-    {% else %}
-      <div class="card glass grain">
-        <h3 class="section-title">Пока нет городов</h3>
-        <p class="page-description">Добавьте город, чтобы настроить городские сообщения.</p>
+  <section class="card glass grain template-panel" data-panel="cities">
+    <header class="template-panel__header">
+      <div>
+        <h3 class="card-title">Шаблоны по городам</h3>
+        <p class="page-description">Локальные тексты перекрывают глобальные шаблоны.</p>
       </div>
-    {% endfor %}
+      {% if overview.cities %}
+        <div class="template-filters">
+          <label class="form-field form-field--wide">
+            <span>Город</span>
+            <select id="city-filter" class="template-filter">
+              <option value="">Все города</option>
+              {% for entry in overview.cities %}
+                <option value="{{ entry.city.id }}">{{ entry.city.name }}</option>
+              {% endfor %}
+            </select>
+          </label>
+        </div>
+      {% endif %}
+    </header>
+    {% if overview.cities %}
+      <div class="list-table-wrapper">
+        <table class="list-table template-table" data-template-table="cities">
+          <thead>
+            <tr>
+              <th scope="col">Город</th>
+              <th scope="col">Этап</th>
+              <th scope="col">Текст</th>
+              <th scope="col" class="col-align-end">Действия</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for entry in overview.cities %}
+              {% for stage in entry.stages %}
+                {% set preview_text = stage.value or stage.default %}
+                <tr
+                  class="template-row{% if stage.is_custom %} is-custom{% endif %}"
+                  data-template-row
+                  data-city="{{ entry.city.id }}"
+                  data-city-name="{{ entry.city.name }}"
+                  data-stage="{{ stage.key }}"
+                  data-stage-title="{{ stage.title }}"
+                  data-default="{{ stage.default|e }}"
+                  data-current="{{ stage.value|e }}"
+                >
+                  <td data-label="Город">
+                    <div class="template-city">
+                      <strong>{{ entry.city.name }}</strong>
+                      <span class="badge" title="Часовой пояс">{{ entry.city.tz or "Europe/Moscow" }}</span>
+                    </div>
+                  </td>
+                  <td data-label="Этап">
+                    <div class="template-stage">
+                      <strong>{{ stage.title }}</strong>
+                      <span class="template-stage__key"><code class="text-mono">{{ stage.key }}</code></span>
+                    </div>
+                  </td>
+                  <td data-label="Текст" class="template-cell">
+                    <div class="template-preview" data-role="preview">{{ preview_text or "—" }}</div>
+                    <div class="template-status-line">
+                      <span class="badge template-status{% if stage.is_custom %} template-status--custom{% endif %}" data-role="status">
+                        {% if stage.is_custom %}Свой текст{% else %}По умолчанию{% endif %}
+                      </span>
+                      <span class="badge muted template-save-indicator" data-role="save-indicator" hidden>Сохранено</span>
+                    </div>
+                    <textarea
+                      class="template-editor"
+                      data-role="editor"
+                      data-default="{{ stage.default|e }}"
+                      rows="6"
+                      hidden
+                    >{{ stage.value or "" }}</textarea>
+                  </td>
+                  <td data-label="Действия" class="col-align-end">
+                    <div class="template-actions" data-role="view-actions">
+                      <button type="button" class="btn btn-soft btn--small" data-action="edit">Редактировать</button>
+                      <button type="button" class="btn btn-ghost btn--small template-action--danger" data-action="clear">Удалить</button>
+                    </div>
+                    <div class="template-actions" data-role="edit-actions" hidden>
+                      <button type="button" class="btn btn-primary btn--small" data-action="save">Сохранить</button>
+                      <button type="button" class="btn btn-soft btn--small" data-action="cancel">Отмена</button>
+                    </div>
+                  </td>
+                </tr>
+              {% endfor %}
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+      <div class="alert mt-sm" data-role="city-empty" hidden>Для выбранного города нет шаблонов.</div>
+      <footer class="template-hint muted">Удаление очищает текст и включает глобальный шаблон.</footer>
+    {% else %}
+      <div class="alert mt-sm">Добавьте город, чтобы настроить локальные сообщения.</div>
+    {% endif %}
   </section>
 
   <section class="card glass grain template-table-card">
@@ -150,60 +253,190 @@
 </section>
 
 <script>
-(function(){
-  const forms = Array.from(document.querySelectorAll('.template-form'));
+(function () {
+  const tabButtons = Array.from(document.querySelectorAll('[data-tab-target]'));
+  const panels = Array.from(document.querySelectorAll('[data-panel]'));
+  const rows = Array.from(document.querySelectorAll('[data-template-row]'));
+  const cityFilter = document.getElementById('city-filter');
+  const cityEmptyState = document.querySelector('[data-role="city-empty"]');
 
-  function gatherPayload(form){
-    const templates = {};
-    form.querySelectorAll('textarea[data-stage]').forEach(ta => {
-      const key = ta.dataset.stage;
-      if (key) templates[key] = ta.value.trim();
+  function activateTab(target) {
+    tabButtons.forEach((btn) => {
+      const isActive = btn.dataset.tabTarget === target;
+      btn.classList.toggle('is-active', isActive);
+      btn.setAttribute('aria-selected', String(isActive));
     });
-    return templates;
+    panels.forEach((panel) => {
+      panel.classList.toggle('is-active', panel.dataset.panel === target);
+    });
   }
 
-  forms.forEach(form => {
-    form.addEventListener('submit', async (e) => {
-      e.preventDefault();
-      const saveBadge = form.querySelector('.save-status');
-      if (saveBadge) {
-        saveBadge.style.display = 'inline-block';
-        saveBadge.classList.remove('ok', 'err');
-        saveBadge.textContent = 'Сохранение…';
-      }
-      const cityId = form.dataset.city || null;
-      try {
-        const resp = await fetch('/templates/save', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ city_id: cityId && cityId !== 'undefined' ? cityId : null, templates: gatherPayload(form) })
-        });
-        const json = await resp.json();
-        if (!json || json.ok !== true) throw new Error(json && json.error || 'Ошибка сохранения');
-        if (saveBadge) {
-          saveBadge.textContent = 'Сохранено';
-          saveBadge.classList.add('ok');
-          setTimeout(() => { saveBadge.style.display = 'none'; saveBadge.classList.remove('ok'); }, 1400);
-        }
-      } catch (err) {
-        if (saveBadge) {
-          saveBadge.textContent = 'Ошибка';
-          saveBadge.classList.add('err');
-        }
-      }
-    });
+  tabButtons.forEach((btn) => {
+    btn.addEventListener('click', () => activateTab(btn.dataset.tabTarget));
   });
 
-  document.addEventListener('click', (e) => {
-    const btn = e.target.closest('.stage-default');
-    if (!btn) return;
-    const field = btn.closest('.stage-field');
-    const textarea = field ? field.querySelector('textarea[data-stage]') : null;
-    if (textarea) {
-      textarea.value = textarea.dataset.default || '';
-      textarea.focus();
+  function updateRowPreview(row, value) {
+    const preview = row.querySelector('[data-role="preview"]');
+    const status = row.querySelector('[data-role="status"]');
+    const indicator = row.querySelector('[data-role="save-indicator"]');
+    const defaultText = row.dataset.default || '';
+    const trimmed = value.trim();
+    const hasCustom = Boolean(trimmed);
+    const text = hasCustom ? trimmed : (defaultText || '');
+    row.dataset.current = value;
+    row.classList.toggle('is-custom', hasCustom);
+    if (preview) {
+      preview.textContent = text || '—';
     }
+    if (status) {
+      status.textContent = hasCustom ? 'Свой текст' : 'По умолчанию';
+      status.classList.toggle('template-status--custom', hasCustom);
+    }
+    if (indicator) {
+      indicator.hidden = true;
+      indicator.classList.remove('is-ok', 'is-error');
+    }
+  }
+
+  function setEditing(row, editing) {
+    const editor = row.querySelector('[data-role="editor"]');
+    const viewActions = row.querySelector('[data-role="view-actions"]');
+    const editActions = row.querySelector('[data-role="edit-actions"]');
+    row.classList.toggle('is-editing', editing);
+    if (editor) {
+      editor.hidden = !editing;
+      if (editing) {
+        editor.focus();
+        editor.setSelectionRange(editor.value.length, editor.value.length);
+      }
+    }
+    if (viewActions) viewActions.hidden = editing;
+    if (editActions) editActions.hidden = !editing;
+  }
+
+  function setLoading(row, loading) {
+    row.classList.toggle('is-loading', loading);
+    row.querySelectorAll('button').forEach((btn) => {
+      btn.disabled = loading;
+    });
+  }
+
+  async function persistRow(row, nextValue) {
+    const key = row.dataset.stage;
+    if (!key) return false;
+    const cityId = row.dataset.city;
+    const indicator = row.querySelector('[data-role="save-indicator"]');
+    const payload = {
+      city_id: cityId ? cityId : null,
+      templates: { [key]: nextValue.trim() },
+    };
+
+    if (indicator) {
+      indicator.hidden = false;
+      indicator.textContent = 'Сохранение…';
+      indicator.classList.remove('is-ok', 'is-error');
+    }
+
+    setLoading(row, true);
+    try {
+      const response = await fetch('/templates/save', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+      const data = await response.json().catch(() => ({}));
+      if (!response.ok || !data || data.ok !== true) {
+        throw new Error(data && data.error ? data.error : 'Ошибка сохранения');
+      }
+      if (indicator) {
+        indicator.textContent = 'Сохранено';
+        indicator.classList.add('is-ok');
+        window.setTimeout(() => {
+          indicator.hidden = true;
+          indicator.classList.remove('is-ok');
+        }, 1400);
+      }
+      updateRowPreview(row, nextValue);
+      setEditing(row, false);
+      return true;
+    } catch (err) {
+      if (indicator) {
+        indicator.textContent = 'Ошибка';
+        indicator.classList.add('is-error');
+      }
+      console.error(err);
+      return false;
+    } finally {
+      setLoading(row, false);
+    }
+  }
+
+  function handleAction(event) {
+    const actionEl = event.target.closest('[data-action]');
+    if (!actionEl) return;
+    const row = actionEl.closest('[data-template-row]');
+    if (!row) return;
+
+    const editor = row.querySelector('[data-role="editor"]');
+    const action = actionEl.dataset.action;
+    if (action === 'edit') {
+      if (editor) editor.value = row.dataset.current || '';
+      setEditing(row, true);
+      return;
+    }
+    if (action === 'cancel') {
+      if (editor) editor.value = row.dataset.current || '';
+      setEditing(row, false);
+      return;
+    }
+    if (action === 'save') {
+      if (!editor) return;
+      const value = editor.value || '';
+      void persistRow(row, value);
+      return;
+    }
+    if (action === 'clear') {
+      const stageTitle = row.dataset.stageTitle || 'шаг';
+      const cityName = row.dataset.cityName;
+      const message = cityName
+        ? `Удалить текст для города «${cityName}» (${stageTitle}) и использовать глобальный шаблон?`
+        : `Удалить глобальный текст для «${stageTitle}» и вернуться к стандартному шаблону?`;
+      if (!window.confirm(message)) {
+        return;
+      }
+      if (editor) editor.value = '';
+      void persistRow(row, '');
+    }
+  }
+
+  document.addEventListener('click', handleAction);
+
+  function applyCityFilter() {
+    if (!cityFilter) return;
+    const value = cityFilter.value;
+    const table = document.querySelector('[data-template-table="cities"]');
+    if (!table) return;
+    const tableRows = Array.from(table.querySelectorAll('[data-template-row]'));
+    let visibleCount = 0;
+    tableRows.forEach((row) => {
+      const matches = !value || row.dataset.city === value;
+      row.hidden = !matches;
+      if (matches) visibleCount += 1;
+    });
+    if (cityEmptyState) {
+      cityEmptyState.hidden = visibleCount !== 0;
+    }
+  }
+
+  if (cityFilter) {
+    cityFilter.addEventListener('change', applyCityFilter);
+  }
+
+  rows.forEach((row) => {
+    updateRowPreview(row, row.dataset.current || '');
   });
+
+  applyCityFilter();
 })();
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- replace the templates management page with tabbed global/city tables that support inline editing, deletion, and filtering
- update styles and scripting to power the new table interactions while keeping templates linked to the bot
- clear the bot template cache whenever templates are created, updated, or deleted so Telegram messages stay in sync

## Testing
- `pytest tests/test_bot_templates.py tests/test_bot_reschedule_reject.py tests/test_bot_test1_notifications.py tests/test_reminder_service.py` *(fails: missing optional deps `sqlalchemy`, `apscheduler` in environment)*


------
https://chatgpt.com/codex/tasks/task_e_68e2929ea8808333b2e2202635e4d9b3