### PR TITLE
Respect BOT_API_BASE when creating Telegram bot

### DIFF
--- a/tests/test_admin_state_nullbot.py
+++ b/tests/test_admin_state_nullbot.py
@@ -38,3 +38,23 @@ async def test_setup_bot_state_without_token(monkeypatch):
         assert app.state.reminder_service is integration.reminder_service
     finally:
         await integration.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_setup_bot_state_with_custom_api_base(monkeypatch):
+    app = FastAPI()
+    base_url = "https://example.invalid"
+
+    monkeypatch.setattr(
+        state_module,
+        "get_settings",
+        lambda: DummySettings(bot_token="123:ABC", bot_api_base=base_url),
+    )
+
+    integration = await state_module.setup_bot_state(app)
+
+    try:
+        assert integration.bot is not None
+        assert integration.bot.session.api.base == base_url
+    finally:
+        await integration.shutdown()

--- a/tests/test_bot_app.py
+++ b/tests/test_bot_app.py
@@ -1,0 +1,21 @@
+import pytest
+
+from backend.apps.bot import app as bot_app
+
+
+class DummySettings:
+    def __init__(self, base: str) -> None:
+        self.bot_api_base = base
+
+
+@pytest.mark.asyncio
+async def test_create_bot_uses_custom_api_base(monkeypatch):
+    base_url = "https://example.invalid"
+    monkeypatch.setattr(bot_app, "get_settings", lambda: DummySettings(base_url))
+
+    bot = bot_app.create_bot(token="123:ABC")
+
+    try:
+        assert bot.session.api.base == base_url
+    finally:
+        await bot.session.close()


### PR DESCRIPTION
## Summary
- use a custom Telegram API session when BOT_API_BASE is configured in the admin UI integration
- apply the same custom session to the bot application factory
- add tests that verify bots point to the configured API base URL

## Testing
- pytest tests/test_admin_state_nullbot.py tests/test_bot_app.py *(fails: ModuleNotFoundError: No module named 'fastapi', 'aiogram')*


------
https://chatgpt.com/codex/tasks/task_e_68e298d9b00c8333afc6438849a2ed02