### PR TITLE
Require recruiter confirmation before sending approved slot message

### DIFF
--- a/backend/apps/bot/handlers/recruiter.py
+++ b/backend/apps/bot/handlers/recruiter.py
@@ -16,6 +16,11 @@ async def approve(callback: CallbackQuery) -> None:
     await services.handle_approve_slot(callback)
 
 
+@router.callback_query(F.data.startswith("sendmsg:"))
+async def send_slot_message(callback: CallbackQuery) -> None:
+    await services.handle_send_slot_message(callback)
+
+
 @router.callback_query(F.data.startswith("reschedule:"))
 async def reschedule(callback: CallbackQuery) -> None:
     await services.handle_reschedule_slot(callback)

--- a/backend/apps/bot/keyboards.py
+++ b/backend/apps/bot/keyboards.py
@@ -163,6 +163,18 @@ def kb_approve(slot_id: int) -> InlineKeyboardMarkup:
     )
 
 
+def kb_send_confirmation(slot_id: int) -> InlineKeyboardMarkup:
+    return InlineKeyboardMarkup(
+        inline_keyboard=[
+            [InlineKeyboardButton(text="📨 Отправить кандидату", callback_data=f"sendmsg:{slot_id}")],
+            [
+                InlineKeyboardButton(text="🔁 Перенести", callback_data=f"reschedule:{slot_id}"),
+                InlineKeyboardButton(text="⛔️ Отказать", callback_data=f"reject:{slot_id}"),
+            ],
+        ]
+    )
+
+
 def kb_attendance_confirm(slot_id: int) -> InlineKeyboardMarkup:
     return InlineKeyboardMarkup(
         inline_keyboard=[
@@ -178,6 +190,7 @@ __all__ = [
     "create_keyboard",
     "fmt_dt_local",
     "kb_approve",
+    "kb_send_confirmation",
     "kb_attendance_confirm",
     "kb_recruiters",
     "kb_slots_for_recruiter",


### PR DESCRIPTION
## Summary
- add a separate inline keyboard to let recruiters confirm sending the approval text to candidates
- render the message preview from admin templates and dispatch it only after an explicit confirmation
- schedule reminders once the candidate notification is sent and expose the new callback handler

## Testing
- pytest *(fails: missing optional dependencies such as aiogram, sqlalchemy, fastapi, redis, apscheduler, pytest_asyncio)*

------
https://chatgpt.com/codex/tasks/task_e_68e29ba03af083339c2eeaff6bddb7c7