### PR TITLE
Delay reminders until recruiter approval

### DIFF
--- a/backend/apps/bot/reminders.py
+++ b/backend/apps/bot/reminders.py
@@ -101,10 +101,7 @@ class ReminderService:
                 return
             if slot.candidate_tg_id is None:
                 return
-            if (slot.status or "").lower() not in {
-                SlotStatus.PENDING,
-                SlotStatus.BOOKED,
-            }:
+            if (slot.status or "").lower() != SlotStatus.BOOKED:
                 return
 
             reminders = self._build_schedule(
@@ -296,8 +293,6 @@ class ReminderService:
         zone = _safe_zone(tz)
         start_local = start_utc.astimezone(zone)
         targets: List[tuple[ReminderKind, timedelta]] = [
-            (ReminderKind.REMIND_24H, timedelta(hours=24)),
-            (ReminderKind.CONFIRM_6H, timedelta(hours=6)),
             (ReminderKind.CONFIRM_2H, timedelta(hours=2)),
             (ReminderKind.REMIND_1H, timedelta(hours=1)),
         ]

--- a/backend/apps/bot/services.py
+++ b/backend/apps/bot/services.py
@@ -1614,13 +1614,6 @@ async def handle_pick_slot(callback: CallbackQuery) -> None:
     )
     await callback.answer()
 
-    try:
-        reminder_service = get_reminder_service()
-    except RuntimeError:
-        reminder_service = None
-    if reminder_service is not None:
-        await reminder_service.schedule_for_slot(slot.id)
-
 
 async def _resolve_candidate_state_for_slot(slot: Slot) -> Dict[str, Any]:
     if slot.candidate_tg_id is None:


### PR DESCRIPTION
## Summary
- stop scheduling candidate reminders when a slot is only reserved and awaiting recruiter approval
- require booked slots for reminder scheduling and keep only the 2-hour confirmation and 1-hour reminder jobs
- refresh reminder service tests to match the streamlined schedule

## Testing
- pytest tests/test_reminder_service.py

------
https://chatgpt.com/codex/tasks/task_e_68e2a34a28308333876b8e6b94090857