### PR TITLE
Enhance manual contact flow to reach responsible recruiter

### DIFF
--- a/backend/apps/bot/config.py
+++ b/backend/apps/bot/config.py
@@ -55,6 +55,8 @@ class State(TypedDict, total=False):
     study_flex: Optional[str]
     test1_payload: Dict[str, Any]
 
+    manual_contact_prompt_sent: bool
+
 
 try:
     _QUESTIONS_BANK = load_all_test_questions()

--- a/backend/apps/bot/handlers/common.py
+++ b/backend/apps/bot/handlers/common.py
@@ -47,8 +47,11 @@ async def cb_contact_manual(callback: CallbackQuery) -> None:
         await callback.answer()
         return
 
-    await services.send_manual_scheduling_prompt(user.id)
-    await callback.answer("Напишите нам в ответном сообщении")
+    sent = await services.send_manual_scheduling_prompt(user.id)
+    if sent:
+        await callback.answer("Откройте чат с рекрутёром по кнопке ниже")
+    else:
+        await callback.answer("Ссылка на рекрутёра уже отправлена выше")
 
 
 @router.callback_query(F.data.startswith("noop:"))

--- a/backend/apps/bot/services.py
+++ b/backend/apps/bot/services.py
@@ -14,7 +14,14 @@ from zoneinfo import ZoneInfo
 
 from aiogram import Bot
 from aiogram.exceptions import TelegramBadRequest
-from aiogram.types import CallbackQuery, ForceReply, Message, FSInputFile
+from aiogram.types import (
+    CallbackQuery,
+    ForceReply,
+    InlineKeyboardButton,
+    InlineKeyboardMarkup,
+    Message,
+    FSInputFile,
+)
 
 from pydantic import ValidationError
 
@@ -26,6 +33,7 @@ from backend.domain.repositories import (
     get_active_recruiters_for_city,
     get_free_slots_by_recruiter,
     get_recruiter,
+    get_city,
     get_slot,
     reject_slot,
     reserve_slot,
@@ -1425,8 +1433,12 @@ async def handle_home_start(callback: CallbackQuery) -> None:
     await begin_interview(callback.from_user.id)
 
 
-async def send_manual_scheduling_prompt(user_id: int) -> None:
-    """Prompt the candidate to reach out when no automatic slots are available."""
+async def send_manual_scheduling_prompt(user_id: int) -> bool:
+    """Prompt the candidate to reach out when no automatic slots are available.
+
+    Returns ``True`` when a new prompt was sent and ``False`` when the candidate
+    has already received the manual contact instructions earlier.
+    """
 
     bot = get_bot()
     state_manager = get_state_manager()
@@ -1436,8 +1448,13 @@ async def send_manual_scheduling_prompt(user_id: int) -> None:
         state = None
 
     city_id: Optional[int] = None
+    manual_prompt_sent = False
     if isinstance(state, dict):
         city_id = state.get("city_id")
+        manual_prompt_sent = bool(state.get("manual_contact_prompt_sent"))
+
+    if manual_prompt_sent:
+        return False
 
     message = await templates.tpl(city_id, "manual_schedule_prompt")
     if not message:
@@ -1446,7 +1463,45 @@ async def send_manual_scheduling_prompt(user_id: int) -> None:
             "и мы подберём время вручную."
         )
 
-    await bot.send_message(user_id, message)
+    reply_markup: Optional[InlineKeyboardMarkup] = None
+    recruiter_label: Optional[str] = None
+
+    if city_id is not None:
+        try:
+            city = await get_city(city_id)
+        except Exception:
+            city = None
+
+        recruiter_id = getattr(city, "responsible_recruiter_id", None)
+        if recruiter_id:
+            try:
+                recruiter = await get_recruiter(int(recruiter_id))
+            except Exception:
+                recruiter = None
+
+            if recruiter and recruiter.tg_chat_id and recruiter.tg_chat_id > 0:
+                recruiter_label = recruiter.name.strip() or "рекрутёром"
+                button = InlineKeyboardButton(
+                    text=f"Написать {recruiter_label}",
+                    url=f"tg://user?id={int(recruiter.tg_chat_id)}",
+                )
+                reply_markup = InlineKeyboardMarkup(inline_keyboard=[[button]])
+
+    if recruiter_label:
+        safe_label = html.escape(recruiter_label)
+        message = (
+            f"{message}\n\nНажмите кнопку ниже, чтобы написать {safe_label}."
+        )
+
+    await bot.send_message(user_id, message, reply_markup=reply_markup)
+
+    def _mark_prompt_sent(st: State) -> Tuple[State, None]:
+        st["manual_contact_prompt_sent"] = True
+        return st, None
+
+    await state_manager.atomic_update(user_id, _mark_prompt_sent)
+
+    return True
 
 
 async def handle_pick_recruiter(callback: CallbackQuery) -> None:

--- a/tests/test_bot_manual_contact.py
+++ b/tests/test_bot_manual_contact.py
@@ -1,0 +1,133 @@
+import pytest
+
+pytest.importorskip("aiogram")
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+from backend.apps.bot import services
+from backend.apps.bot.config import DEFAULT_TZ, State
+from backend.apps.bot.state_store import InMemoryStateStore, StateManager
+from backend.core.db import async_session
+from backend.domain import models
+
+USER_ID = 987654
+
+
+@pytest.mark.asyncio
+async def test_manual_contact_links_responsible_recruiter(monkeypatch):
+    store = InMemoryStateStore(ttl_seconds=60)
+    manager = StateManager(store)
+    dummy_bot = SimpleNamespace(
+        send_message=AsyncMock(),
+        session=SimpleNamespace(close=AsyncMock()),
+    )
+
+    monkeypatch.setattr(services, "_bot", dummy_bot)
+    monkeypatch.setattr(services, "_state_manager", manager)
+
+    async with async_session() as session:
+        recruiter = models.Recruiter(
+            name="Анна Рекрутер",
+            tz="Europe/Moscow",
+            active=True,
+            tg_chat_id=123456789,
+        )
+        session.add(recruiter)
+        await session.flush()
+        city = models.City(
+            name="Тестоград",
+            tz="Europe/Moscow",
+            active=True,
+            responsible_recruiter_id=recruiter.id,
+        )
+        session.add(city)
+        await session.commit()
+        city_id = city.id
+
+    await manager.set(
+        USER_ID,
+        State(
+            flow="interview",
+            city_id=city_id,
+            candidate_tz=DEFAULT_TZ,
+        ),
+    )
+
+    first = await services.send_manual_scheduling_prompt(USER_ID)
+    assert first is True
+    assert dummy_bot.send_message.await_count == 1
+
+    call = dummy_bot.send_message.await_args_list[0]
+    kwargs = call.kwargs
+    markup = kwargs.get("reply_markup")
+    assert markup is not None, "expected contact link for responsible recruiter"
+    button = markup.inline_keyboard[0][0]
+    assert button.url == "tg://user?id=123456789"
+    assert "Анна" in kwargs.get("text", "")
+
+    state = await manager.get(USER_ID)
+    assert state.get("manual_contact_prompt_sent") is True
+
+    second = await services.send_manual_scheduling_prompt(USER_ID)
+    assert second is False
+    assert dummy_bot.send_message.await_count == 1
+
+    await manager.clear()
+    await manager.close()
+
+
+@pytest.mark.asyncio
+async def test_manual_contact_without_responsible_link(monkeypatch):
+    store = InMemoryStateStore(ttl_seconds=60)
+    manager = StateManager(store)
+    dummy_bot = SimpleNamespace(
+        send_message=AsyncMock(),
+        session=SimpleNamespace(close=AsyncMock()),
+    )
+
+    monkeypatch.setattr(services, "_bot", dummy_bot)
+    monkeypatch.setattr(services, "_state_manager", manager)
+
+    async with async_session() as session:
+        recruiter = models.Recruiter(
+            name="Без Чата",
+            tz="Europe/Moscow",
+            active=True,
+            tg_chat_id=None,
+        )
+        session.add(recruiter)
+        await session.flush()
+        city = models.City(
+            name="Нетлинк",
+            tz="Europe/Moscow",
+            active=True,
+            responsible_recruiter_id=recruiter.id,
+        )
+        session.add(city)
+        await session.commit()
+        city_id = city.id
+
+    await manager.set(
+        USER_ID,
+        State(
+            flow="interview",
+            city_id=city_id,
+            candidate_tz=DEFAULT_TZ,
+        ),
+    )
+
+    first = await services.send_manual_scheduling_prompt(USER_ID)
+    assert first is True
+
+    call = dummy_bot.send_message.await_args_list[0]
+    kwargs = call.kwargs
+    markup = kwargs.get("reply_markup")
+    assert markup is None, "no link expected when recruiter chat is missing"
+
+    second = await services.send_manual_scheduling_prompt(USER_ID)
+    assert second is False
+    assert dummy_bot.send_message.await_count == 1
+
+    await manager.clear()
+    await manager.close()


### PR DESCRIPTION
## Summary
- track that the manual contact prompt has been delivered so repeated taps do not spam the chat
- resolve the responsible recruiter for the candidate's city and send a button that opens their chat when manual help is requested
- cover the new behaviour with focused tests for manual contact, including the case without a recruiter chat

## Testing
- pytest tests/test_bot_manual_contact.py (skipped: aiogram missing)


------
https://chatgpt.com/codex/tasks/task_e_68e333f36dc08333acfbe1e7cb59b40d