### PR TITLE
Add concurrent indexes for candidate lookups

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,4 +117,4 @@ python -c "from backend.migrations import upgrade_to_head; upgrade_to_head()"
 The seeding step is idempotent and can be executed multiple times without
 creating duplicate cities, recruiters or test questions.
 
-> **Note:** The latest migrations require PostgreSQL because they rely on concurrent index operations.
+> **Note:** The latest migrations require PostgreSQL because they rely on concurrent index operations (e.g. `CREATE INDEX CONCURRENTLY`).

--- a/backend/migrations/versions/0010_add_concurrent_candidate_indexes.py
+++ b/backend/migrations/versions/0010_add_concurrent_candidate_indexes.py
@@ -1,0 +1,65 @@
+"""Add concurrent indexes for candidate and auto message lookups."""
+
+from __future__ import annotations
+
+from typing import Tuple
+
+from alembic.operations import Operations
+from alembic.runtime.migration import MigrationContext
+from sqlalchemy.engine import Connection
+
+
+revision = "0010_add_concurrent_candidate_indexes"
+down_revision = "0009_add_missing_indexes"
+branch_labels = None
+depends_on = None
+
+
+INDEX_DEFINITIONS = (
+    ("slots", "ix_slots_candidate_tg_id", ["candidate_tg_id"]),
+    ("auto_messages", "ix_auto_messages_target_chat_id", ["target_chat_id"]),
+)
+
+
+def _get_operations(conn: Connection) -> Tuple[Operations, MigrationContext, Connection]:
+    standalone_conn = conn.engine.connect() if hasattr(conn, "engine") else conn
+    context = MigrationContext.configure(connection=standalone_conn)
+    return Operations(context), context, standalone_conn
+
+
+def upgrade(conn: Connection) -> None:
+    op, context, standalone_conn = _get_operations(conn)
+
+    try:
+        with context.begin_transaction():
+            for table_name, index_name, columns in INDEX_DEFINITIONS:
+                with context.autocommit_block():
+                    op.create_index(
+                        index_name,
+                        table_name,
+                        columns,
+                        unique=False,
+                        postgresql_concurrently=True,
+                        if_not_exists=True,
+                    )
+    finally:
+        if standalone_conn is not conn:
+            standalone_conn.close()
+
+
+def downgrade(conn: Connection) -> None:  # pragma: no cover - symmetry only
+    op, context, standalone_conn = _get_operations(conn)
+
+    try:
+        with context.begin_transaction():
+            for table_name, index_name, _ in INDEX_DEFINITIONS:
+                with context.autocommit_block():
+                    op.drop_index(
+                        index_name,
+                        table_name=table_name,
+                        postgresql_concurrently=True,
+                        if_exists=True,
+                    )
+    finally:
+        if standalone_conn is not conn:
+            standalone_conn.close()


### PR DESCRIPTION
## Summary
- add a dedicated Alembic migration that creates the slots and auto_messages indexes with CREATE INDEX CONCURRENTLY
- ensure the downgrade path removes the indexes with DROP INDEX CONCURRENTLY for compatibility
- document that the migration requires PostgreSQL because of concurrent index usage

## Testing
- python -m backend.migrations.runner

------
https://chatgpt.com/codex/tasks/task_e_68e352ad68308333af8124780476b417