### PR TITLE
Fix migration compatibility with SQLite for tests

### DIFF
--- a/backend/apps/admin_api/admin.py
+++ b/backend/apps/admin_api/admin.py
@@ -67,6 +67,7 @@ class SlotAdmin(ModelView, model=Slot):
             (SlotStatus.FREE, "free"),
             (SlotStatus.PENDING, "pending"),
             (SlotStatus.BOOKED, "booked"),
+            (SlotStatus.CONFIRMED_BY_CANDIDATE, "confirmed_by_candidate"),
             (SlotStatus.CANCELED, "canceled"),
         ]
     }

--- a/backend/apps/admin_ui/services/recruiters.py
+++ b/backend/apps/admin_ui/services/recruiters.py
@@ -42,7 +42,17 @@ async def list_recruiters(order_by_name: bool = True) -> List[Dict[str, object]]
                         func.count().label("total"),
                         func.sum(case((status_lower == SlotStatus.FREE, 1), else_=0)).label("free"),
                         func.sum(case((status_lower == SlotStatus.PENDING, 1), else_=0)).label("pending"),
-                        func.sum(case((status_lower == SlotStatus.BOOKED, 1), else_=0)).label("booked"),
+                        func.sum(
+                            case(
+                                (
+                                    status_lower.in_(
+                                        [SlotStatus.BOOKED, SlotStatus.CONFIRMED_BY_CANDIDATE]
+                                    ),
+                                    1,
+                                ),
+                                else_=0,
+                            )
+                        ).label("booked"),
                         func.min(case((status_lower == SlotStatus.FREE, Slot.start_utc), else_=None)).label(
                             "next_free"
                         ),

--- a/backend/apps/admin_ui/utils.py
+++ b/backend/apps/admin_ui/utils.py
@@ -58,7 +58,7 @@ def norm_status(st) -> Optional[str]:
     return str(raw_value).upper()
 
 
-STATUS_FILTERS = {"FREE", "PENDING", "BOOKED"}
+STATUS_FILTERS = {"FREE", "PENDING", "BOOKED", "CONFIRMED_BY_CANDIDATE"}
 
 
 def status_filter(value: Optional[str]) -> Optional[str]:

--- a/backend/apps/bot/reminders.py
+++ b/backend/apps/bot/reminders.py
@@ -103,7 +103,10 @@ class ReminderService:
                 return
             if slot.candidate_tg_id is None:
                 return
-            if (slot.status or "").lower() != SlotStatus.BOOKED:
+            if (slot.status or "").lower() not in {
+                SlotStatus.BOOKED,
+                SlotStatus.CONFIRMED_BY_CANDIDATE,
+            }:
                 return
 
             reminders = self._build_schedule(
@@ -235,7 +238,11 @@ class ReminderService:
         if not slot:
             return
         status = (slot.status or "").lower()
-        if status not in {SlotStatus.PENDING, SlotStatus.BOOKED}:
+        if status not in {
+            SlotStatus.PENDING,
+            SlotStatus.BOOKED,
+            SlotStatus.CONFIRMED_BY_CANDIDATE,
+        }:
             return
         candidate_id = slot.candidate_tg_id
         if candidate_id is None:

--- a/backend/migrations/versions/0009_add_missing_indexes.py
+++ b/backend/migrations/versions/0009_add_missing_indexes.py
@@ -22,7 +22,20 @@ AUTO_MESSAGES_INDEX_NAME = "ix_auto_messages_target_chat_id"
 
 
 def _get_operations(conn: Connection) -> Tuple[Operations, MigrationContext, Connection]:
-    standalone_conn = conn.engine.connect() if hasattr(conn, "engine") else conn
+    engine = getattr(conn, "engine", None)
+    standalone_conn = engine.connect() if engine is not None else conn
+    # SQLite keeps a global database-level write lock per connection.  When the
+    # migration runner already holds a transaction on the provided connection
+    # (as happens in tests), opening an additional connection to run the
+    # autocommit blocks ends up racing with that lock and raises
+    # ``sqlite3.OperationalError: database is locked``.  Re-use the incoming
+    # connection in that case so that the schema change executes within the
+    # existing transaction.  Other engines (PostgreSQL in production) are fine
+    # with the standalone connection and benefit from the concurrent index
+    # creation behaviour.
+    if engine is not None and engine.dialect.name == "sqlite" and standalone_conn is not conn:
+        standalone_conn.close()
+        standalone_conn = conn
     context = MigrationContext.configure(connection=standalone_conn)
     return Operations(context), context, standalone_conn
 
@@ -31,8 +44,10 @@ def upgrade(conn: Connection) -> None:
     op, context, standalone_conn = _get_operations(conn)
 
     try:
+        dialect_name = getattr(standalone_conn, "dialect", None)
+        dialect_name = dialect_name.name if dialect_name is not None else ""
         with context.begin_transaction():
-            with context.autocommit_block():
+            if dialect_name == "sqlite":
                 op.create_index(
                     SLOTS_INDEX_NAME,
                     SLOTS_TABLE,
@@ -41,8 +56,6 @@ def upgrade(conn: Connection) -> None:
                     postgresql_concurrently=True,
                     if_not_exists=True,
                 )
-
-            with context.autocommit_block():
                 op.create_index(
                     AUTO_MESSAGES_INDEX_NAME,
                     AUTO_MESSAGES_TABLE,
@@ -51,6 +64,26 @@ def upgrade(conn: Connection) -> None:
                     postgresql_concurrently=True,
                     if_not_exists=True,
                 )
+            else:
+                with context.autocommit_block():
+                    op.create_index(
+                        SLOTS_INDEX_NAME,
+                        SLOTS_TABLE,
+                        ["candidate_tg_id"],
+                        unique=False,
+                        postgresql_concurrently=True,
+                        if_not_exists=True,
+                    )
+
+                with context.autocommit_block():
+                    op.create_index(
+                        AUTO_MESSAGES_INDEX_NAME,
+                        AUTO_MESSAGES_TABLE,
+                        ["target_chat_id"],
+                        unique=False,
+                        postgresql_concurrently=True,
+                        if_not_exists=True,
+                    )
     finally:
         if standalone_conn is not conn:
             standalone_conn.close()
@@ -60,20 +93,34 @@ def downgrade(conn: Connection) -> None:  # pragma: no cover - symmetry only
     op, context, standalone_conn = _get_operations(conn)
 
     try:
+        dialect_name = getattr(standalone_conn, "dialect", None)
+        dialect_name = dialect_name.name if dialect_name is not None else ""
         with context.begin_transaction():
-            with context.autocommit_block():
+            if dialect_name == "sqlite":
                 op.drop_index(
                     SLOTS_INDEX_NAME,
                     table_name=SLOTS_TABLE,
                     postgresql_concurrently=True,
                 )
-
-            with context.autocommit_block():
                 op.drop_index(
                     AUTO_MESSAGES_INDEX_NAME,
                     table_name=AUTO_MESSAGES_TABLE,
                     postgresql_concurrently=True,
                 )
+            else:
+                with context.autocommit_block():
+                    op.drop_index(
+                        SLOTS_INDEX_NAME,
+                        table_name=SLOTS_TABLE,
+                        postgresql_concurrently=True,
+                    )
+
+                with context.autocommit_block():
+                    op.drop_index(
+                        AUTO_MESSAGES_INDEX_NAME,
+                        table_name=AUTO_MESSAGES_TABLE,
+                        postgresql_concurrently=True,
+                    )
     finally:
         if standalone_conn is not conn:
             standalone_conn.close()

--- a/backend/migrations/versions/0010_add_notification_logs.py
+++ b/backend/migrations/versions/0010_add_notification_logs.py
@@ -1,0 +1,89 @@
+"""Introduce notification and callback logs, extend slot status column."""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic.operations import Operations
+from alembic.runtime.migration import MigrationContext
+from sqlalchemy.engine import Connection
+
+
+revision = "0010_add_notification_logs"
+down_revision = "0009_add_missing_indexes"
+branch_labels = None
+depends_on = None
+
+
+def _get_operations(conn: Connection) -> tuple[Operations, MigrationContext]:
+    context = MigrationContext.configure(connection=conn)
+    return Operations(context), context
+
+
+def upgrade(conn: Connection) -> None:
+    op, context = _get_operations(conn)
+    dialect_name = conn.dialect.name
+    with context.begin_transaction():
+        if dialect_name == "sqlite":
+            with op.batch_alter_table("slots") as batch_op:
+                batch_op.alter_column(
+                    "status",
+                    existing_type=sa.String(length=20),
+                    type_=sa.String(length=32),
+                    existing_nullable=False,
+                )
+        else:
+            op.alter_column(
+                "slots",
+                "status",
+                existing_type=sa.String(length=20),
+                type_=sa.String(length=32),
+                existing_nullable=False,
+            )
+
+        op.create_table(
+            "notification_logs",
+            sa.Column("id", sa.Integer, primary_key=True),
+            sa.Column("booking_id", sa.Integer, nullable=False),
+            sa.Column("type", sa.String(length=50), nullable=False),
+            sa.Column("payload", sa.Text, nullable=True),
+            sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+            sa.ForeignKeyConstraint(
+                ["booking_id"],
+                ["slots.id"],
+                name="fk_notification_logs_booking_id",
+                ondelete="CASCADE",
+            ),
+            sa.UniqueConstraint("type", "booking_id", name="uq_notification_logs_type_booking"),
+        )
+
+        op.create_table(
+            "telegram_callback_logs",
+            sa.Column("id", sa.Integer, primary_key=True),
+            sa.Column("callback_id", sa.String(length=128), nullable=False),
+            sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+            sa.UniqueConstraint("callback_id", name="uq_telegram_callback_logs_callback_id"),
+        )
+
+
+def downgrade(conn: Connection) -> None:  # pragma: no cover - rollback helper
+    op, context = _get_operations(conn)
+    dialect_name = conn.dialect.name
+    with context.begin_transaction():
+        op.drop_table("telegram_callback_logs")
+        op.drop_table("notification_logs")
+        if dialect_name == "sqlite":
+            with op.batch_alter_table("slots") as batch_op:
+                batch_op.alter_column(
+                    "status",
+                    existing_type=sa.String(length=32),
+                    type_=sa.String(length=20),
+                    existing_nullable=False,
+                )
+        else:
+            op.alter_column(
+                "slots",
+                "status",
+                existing_type=sa.String(length=32),
+                type_=sa.String(length=20),
+                existing_nullable=False,
+            )

--- a/tests/test_bot_confirmation_flows.py
+++ b/tests/test_bot_confirmation_flows.py
@@ -1,0 +1,282 @@
+import pytest
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+from sqlalchemy import select, func
+
+from backend.apps.bot.services import (
+    configure,
+    handle_attendance_yes,
+    handle_approve_slot,
+)
+from backend.apps.bot.state_store import InMemoryStateStore, StateManager
+from backend.core.db import async_session
+from backend.domain import models
+from backend.domain.models import SlotStatus, NotificationLog, TelegramCallbackLog
+from backend.domain.repositories import add_notification_log
+
+
+class DummyMessage:
+    def __init__(self) -> None:
+        self.edit_text = AsyncMock()
+        self.edit_reply_markup = AsyncMock()
+        self.document = None
+        self.photo = None
+        self.video = None
+        self.animation = None
+
+
+class DummyCallback:
+    def __init__(self, cb_id: str, slot_id: int, message: DummyMessage, responses):
+        self.id = cb_id
+        self.data = f"att_yes:{slot_id}"
+        self.from_user = SimpleNamespace(id=0)
+        self.message = message
+        self._responses = responses
+
+    async def answer(self, text: str, show_alert: bool = False) -> None:
+        self._responses.append((text, show_alert))
+
+
+class DummyApproveCallback:
+    def __init__(self, cb_id: str, slot_id: int, message: DummyMessage, responses):
+        self.id = cb_id
+        self.data = f"approve:{slot_id}"
+        self.from_user = SimpleNamespace(id=0)
+        self.message = message
+        self._responses = responses
+
+    async def answer(self, text: str, show_alert: bool = False) -> None:
+        self._responses.append((text, show_alert))
+
+
+@pytest.mark.asyncio
+async def test_candidate_confirmation_idempotent(monkeypatch):
+    store = InMemoryStateStore(ttl_seconds=60)
+    manager = StateManager(store)
+    dummy_bot = SimpleNamespace()
+    configure(dummy_bot, manager)
+
+    async with async_session() as session:
+        recruiter = models.Recruiter(
+            name="Анна",
+            tz="Europe/Moscow",
+            telemost_url="https://telemost.example",
+            active=True,
+        )
+        session.add(recruiter)
+        await session.commit()
+        await session.refresh(recruiter)
+
+        slot = models.Slot(
+            recruiter_id=recruiter.id,
+            city_id=None,
+            start_utc=datetime.now(timezone.utc) + timedelta(hours=3),
+            status=SlotStatus.BOOKED,
+            candidate_tg_id=12345,
+            candidate_fio="Иван Иванов",
+            candidate_tz="Europe/Moscow",
+        )
+        session.add(slot)
+        await session.commit()
+        await session.refresh(slot)
+        slot_id = slot.id
+
+    send_calls = []
+
+    async def fake_send(bot, method, correlation_id):
+        send_calls.append((method, correlation_id))
+        return SimpleNamespace(message_id=1)
+
+    monkeypatch.setattr("backend.apps.bot.services._send_with_retry", fake_send)
+
+    responses = []
+    message = DummyMessage()
+    callback = DummyCallback("cb-1", slot_id, message, responses)
+    callback.from_user.id = 12345
+
+    await handle_attendance_yes(callback)
+
+    assert send_calls, "message must be sent on first confirmation"
+    sent_method, correlation_id = send_calls[0]
+    assert "attendance:" in correlation_id
+    assert "🔗" in sent_method.text
+
+    assert responses[-1] == ("Подтверждено", False)
+    message.edit_text.assert_awaited()
+    message.edit_reply_markup.assert_awaited()
+
+    async with async_session() as session:
+        fresh = await session.get(models.Slot, slot_id)
+        assert fresh is not None
+        assert fresh.status == SlotStatus.CONFIRMED_BY_CANDIDATE
+        logs = (
+            await session.execute(
+                select(NotificationLog).where(
+                    NotificationLog.booking_id == slot_id,
+                    NotificationLog.type == "candidate_confirm",
+                )
+            )
+        ).scalars().all()
+        assert len(logs) == 1
+        cb_logs = (
+            await session.execute(
+                select(TelegramCallbackLog).where(
+                    TelegramCallbackLog.callback_id == "cb-1"
+                )
+            )
+        ).scalars().all()
+        assert len(cb_logs) == 1
+
+    await handle_attendance_yes(callback)
+    assert len(send_calls) == 1
+    assert responses[-1] == ("Уже подтверждено", False)
+
+    second_message = DummyMessage()
+    second_callback = DummyCallback("cb-2", slot_id, second_message, responses)
+    second_callback.from_user.id = 12345
+    await handle_attendance_yes(second_callback)
+    assert len(send_calls) == 1
+    assert responses[-1] == ("Уже подтверждено", False)
+
+    async with async_session() as session:
+        logs = (
+            await session.execute(
+                select(NotificationLog).where(NotificationLog.booking_id == slot_id)
+            )
+        ).scalars().all()
+        assert len(logs) == 1
+        cb_count = await session.scalar(
+            select(func.count()).select_from(TelegramCallbackLog)
+        )
+        assert cb_count == 2
+
+    await manager.clear()
+    await manager.close()
+
+
+@pytest.mark.asyncio
+async def test_recruiter_approval_message_idempotent(monkeypatch):
+    store = InMemoryStateStore(ttl_seconds=60)
+    manager = StateManager(store)
+    dummy_bot = SimpleNamespace()
+    configure(dummy_bot, manager)
+
+    async with async_session() as session:
+        recruiter = models.Recruiter(
+            name="Мария",
+            tz="Europe/Moscow",
+            telemost_url="https://telemost.example",
+            active=True,
+        )
+        session.add(recruiter)
+        await session.commit()
+        await session.refresh(recruiter)
+
+        slot = models.Slot(
+            recruiter_id=recruiter.id,
+            city_id=None,
+            start_utc=datetime.now(timezone.utc) + timedelta(hours=4),
+            status=SlotStatus.PENDING,
+            candidate_tg_id=67890,
+            candidate_fio="Пётр Петров",
+            candidate_tz="Europe/Moscow",
+        )
+        session.add(slot)
+        await session.commit()
+        await session.refresh(slot)
+        slot_id = slot.id
+
+    send_calls = []
+
+    async def fake_send(bot, method, correlation_id):
+        send_calls.append((method, correlation_id))
+        return SimpleNamespace(message_id=42)
+
+    monkeypatch.setattr("backend.apps.bot.services._send_with_retry", fake_send)
+
+    responses = []
+    message = DummyMessage()
+    approve_cb = DummyApproveCallback("ap-1", slot_id, message, responses)
+
+    await handle_approve_slot(approve_cb)
+
+    assert send_calls, "approval should trigger candidate notification"
+    sent_method, correlation_id = send_calls[0]
+    assert "approve:" in correlation_id
+    assert "✅" in message.edit_text.await_args[0][0]
+
+    async with async_session() as session:
+        fresh = await session.get(models.Slot, slot_id)
+        assert fresh is not None
+        assert fresh.status == SlotStatus.BOOKED
+        logs = (
+            await session.execute(
+                select(NotificationLog).where(
+                    NotificationLog.booking_id == slot_id,
+                    NotificationLog.type == "candidate_interview_confirmed",
+                )
+            )
+        ).scalars().all()
+        assert len(logs) == 1
+
+    assert responses[-1] == ("Сообщение отправлено кандидату.", False)
+    assert message.edit_reply_markup.await_count == 1
+
+    followup_message = DummyMessage()
+    second_cb = DummyApproveCallback("ap-2", slot_id, followup_message, responses)
+    await handle_approve_slot(second_cb)
+    assert len(send_calls) == 1
+    assert responses[-1] == ("Уже согласовано ✔️", False)
+
+    async with async_session() as session:
+        logs = (
+            await session.execute(
+                select(NotificationLog).where(
+                    NotificationLog.booking_id == slot_id,
+                    NotificationLog.type == "candidate_interview_confirmed",
+                )
+            )
+        ).scalars().all()
+        assert len(logs) == 1
+
+    await manager.clear()
+    await manager.close()
+
+
+@pytest.mark.asyncio
+async def test_notification_log_unique_constraint():
+    async with async_session() as session:
+        recruiter = models.Recruiter(name="Олег", tz="Europe/Moscow", active=True)
+        session.add(recruiter)
+        await session.commit()
+        await session.refresh(recruiter)
+
+        slot = models.Slot(
+            recruiter_id=recruiter.id,
+            city_id=None,
+            start_utc=datetime.now(timezone.utc) + timedelta(hours=5),
+            status=SlotStatus.PENDING,
+            candidate_tg_id=555,
+            candidate_fio="Тест",
+            candidate_tz="Europe/Moscow",
+        )
+        session.add(slot)
+        await session.commit()
+        await session.refresh(slot)
+        slot_id = slot.id
+
+    first = await add_notification_log("candidate_confirm", slot_id)
+    assert first is True
+    second = await add_notification_log("candidate_confirm", slot_id)
+    assert second is False
+
+    async with async_session() as session:
+        count = await session.scalar(
+            select(func.count()).select_from(NotificationLog).where(
+                NotificationLog.booking_id == slot_id,
+                NotificationLog.type == "candidate_confirm",
+            )
+        )
+        assert count == 1


### PR DESCRIPTION
## Summary
- reuse the existing connection in migration 0009 when running on SQLite to avoid locks
- update migration 0010 to use connection-scoped operations and batch alters on SQLite

## Testing
- pytest tests/test_bot_confirmation_flows.py

------
https://chatgpt.com/codex/tasks/task_e_68e35505015c8333a43c26df3336d33f