### PR TITLE
Fix notification logs and booking constraints

### DIFF
--- a/backend/apps/admin_ui/routers/slots.py
+++ b/backend/apps/admin_ui/routers/slots.py
@@ -88,6 +88,9 @@ async def slots_list(
         "FREE": int(aggregated.get("FREE", 0)),
         "PENDING": int(aggregated.get("PENDING", 0)),
         "BOOKED": int(aggregated.get("BOOKED", 0)),
+        "CONFIRMED_BY_CANDIDATE": int(
+            aggregated.get("CONFIRMED_BY_CANDIDATE", 0)
+        ),
     }
     flash = _pop_flash(request)
     context = {

--- a/backend/apps/admin_ui/services/slots.py
+++ b/backend/apps/admin_ui/services/slots.py
@@ -96,6 +96,7 @@ async def list_slots(
         aggregated: Dict[str, int] = {}
         for raw_status, count in status_rows:
             aggregated[norm_status(raw_status)] = int(count or 0)
+        aggregated.setdefault("CONFIRMED_BY_CANDIDATE", 0)
 
         pages_total, page, offset = paginate(total, page, per_page)
 

--- a/backend/apps/admin_ui/templates/slots_list.html
+++ b/backend/apps/admin_ui/templates/slots_list.html
@@ -40,6 +40,11 @@
       <span class="slot-summary__value" id="cnt-booked">{{ status_counts.BOOKED }}</span>
       <p class="slot-summary__hint">Интервью назначены кандидатам</p>
     </article>
+    <article class="slot-summary__item" data-tone="primary">
+      <span class="slot-summary__label">Подтверждены</span>
+      <span class="slot-summary__value" id="cnt-confirmed">{{ status_counts.CONFIRMED_BY_CANDIDATE }}</span>
+      <p class="slot-summary__hint">Кандидаты подтвердили участие</p>
+    </article>
     <article class="slot-summary__item" data-tone="neutral">
       <span class="slot-summary__label">Всего</span>
       <span class="slot-summary__value" id="cnt-total">{{ status_counts.total }}</span>
@@ -73,6 +78,7 @@
         <option value="FREE" {% if filter_status == 'FREE' %}selected{% endif %}>FREE</option>
         <option value="PENDING" {% if filter_status == 'PENDING' %}selected{% endif %}>PENDING</option>
         <option value="BOOKED" {% if filter_status == 'BOOKED' %}selected{% endif %}>BOOKED</option>
+        <option value="CONFIRMED_BY_CANDIDATE" {% if filter_status == 'CONFIRMED_BY_CANDIDATE' %}selected{% endif %}>CONFIRMED_BY_CANDIDATE</option>
       </select>
     </div>
 

--- a/backend/apps/bot/services.py
+++ b/backend/apps/bot/services.py
@@ -1834,7 +1834,9 @@ async def handle_approve_slot(callback: CallbackQuery) -> None:
         return
 
     already_sent = await notification_log_exists(
-        "candidate_interview_confirmed", slot.id
+        "candidate_interview_confirmed",
+        slot.id,
+        candidate_tg_id=slot.candidate_tg_id,
     )
 
     message_text, candidate_tz, candidate_city = await _render_candidate_notification(slot)
@@ -1878,6 +1880,7 @@ async def handle_approve_slot(callback: CallbackQuery) -> None:
         logged = await add_notification_log(
             "candidate_interview_confirmed",
             slot.id,
+            candidate_tg_id=slot.candidate_tg_id,
             payload=message_text,
         )
         if not logged:

--- a/backend/domain/models.py
+++ b/backend/domain/models.py
@@ -10,6 +10,7 @@ from sqlalchemy import (
     DateTime,
     Text,
     ForeignKey,
+    Index,
     UniqueConstraint,
 )
 from sqlalchemy.orm import Mapped, mapped_column, relationship, validates
@@ -205,13 +206,20 @@ class TestQuestion(Base):
 class NotificationLog(Base):
     __tablename__ = "notification_logs"
     __table_args__ = (
-        UniqueConstraint("type", "booking_id", name="uq_notification_logs_type_booking"),
+        Index(
+            "uq_notif_type_booking_candidate",
+            "type",
+            "booking_id",
+            "candidate_tg_id",
+            unique=True,
+        ),
     )
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
     booking_id: Mapped[int] = mapped_column(
         ForeignKey("slots.id", ondelete="CASCADE"), nullable=False
     )
+    candidate_tg_id: Mapped[Optional[int]] = mapped_column(BigInteger, nullable=True)
     type: Mapped[str] = mapped_column(String(50), nullable=False)
     payload: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     created_at: Mapped[datetime] = mapped_column(

--- a/backend/migrations/versions/0011_add_candidate_binding_to_notification_logs.py
+++ b/backend/migrations/versions/0011_add_candidate_binding_to_notification_logs.py
@@ -1,0 +1,139 @@
+from typing import Tuple
+
+import sqlalchemy as sa
+from alembic.operations import Operations
+from alembic.runtime.migration import MigrationContext
+from sqlalchemy.engine import Connection
+
+
+revision = "0011_add_candidate_binding_to_notification_logs"
+down_revision = "0010_add_notification_logs"
+branch_labels = None
+depends_on = None
+
+
+TABLE_NAME = "notification_logs"
+CANDIDATE_COLUMN = "candidate_tg_id"
+OLD_CONSTRAINT = "uq_notification_logs_type_booking"
+NEW_INDEX = "uq_notif_type_booking_candidate"
+
+
+def _get_operations(conn: Connection) -> Tuple[Operations, MigrationContext, Connection]:
+    engine = getattr(conn, "engine", None)
+    standalone_conn = engine.connect() if engine is not None else conn
+    if engine is not None and engine.dialect.name == "sqlite" and standalone_conn is not conn:
+        standalone_conn.close()
+        standalone_conn = conn
+    context = MigrationContext.configure(connection=standalone_conn)
+    return Operations(context), context, standalone_conn
+
+
+def upgrade(conn: Connection) -> None:
+    op, context, standalone_conn = _get_operations(conn)
+
+    try:
+        dialect_name = getattr(standalone_conn, "dialect", None)
+        dialect_name = dialect_name.name if dialect_name is not None else ""
+
+        with context.begin_transaction():
+            op.add_column(
+                TABLE_NAME,
+                sa.Column(CANDIDATE_COLUMN, sa.BigInteger(), nullable=True),
+            )
+
+            if dialect_name == "sqlite":
+                op.execute(sa.text(f"DROP INDEX IF EXISTS {OLD_CONSTRAINT}"))
+                op.execute(
+                    sa.text(
+                        """
+                        UPDATE {table}
+                           SET {column} = (
+                               SELECT candidate_tg_id
+                                 FROM slots
+                                WHERE slots.id = {table}.booking_id
+                           )
+                         WHERE {column} IS NULL
+                           AND EXISTS (
+                               SELECT 1 FROM slots
+                                WHERE slots.id = {table}.booking_id
+                                  AND slots.candidate_tg_id IS NOT NULL
+                           )
+                        """.format(table=TABLE_NAME, column=CANDIDATE_COLUMN)
+                    )
+                )
+                op.execute(
+                    sa.text(
+                        """
+                        CREATE UNIQUE INDEX {name}
+                            ON {table} (type, booking_id, {column})
+                        """.format(
+                            name=NEW_INDEX,
+                            table=TABLE_NAME,
+                            column=CANDIDATE_COLUMN,
+                        )
+                    )
+                )
+            else:
+                op.drop_constraint(OLD_CONSTRAINT, TABLE_NAME, type_="unique")
+                op.execute(
+                    sa.text(
+                        """
+                        UPDATE {table} nl
+                           SET {column} = s.candidate_tg_id
+                          FROM slots s
+                         WHERE nl.booking_id = s.id
+                           AND nl.{column} IS NULL
+                           AND s.candidate_tg_id IS NOT NULL
+                        """.format(table=TABLE_NAME, column=CANDIDATE_COLUMN)
+                    )
+                )
+
+                with context.autocommit_block():
+                    op.create_index(
+                        NEW_INDEX,
+                        TABLE_NAME,
+                        ["type", "booking_id", CANDIDATE_COLUMN],
+                        unique=True,
+                        postgresql_concurrently=True,
+                    )
+    finally:
+        if standalone_conn is not conn:
+            standalone_conn.close()
+
+
+def downgrade(conn: Connection) -> None:  # pragma: no cover - rollback helper
+    op, context, standalone_conn = _get_operations(conn)
+
+    try:
+        dialect_name = getattr(standalone_conn, "dialect", None)
+        dialect_name = dialect_name.name if dialect_name is not None else ""
+
+        with context.begin_transaction():
+            if dialect_name == "sqlite":
+                op.execute(sa.text(f"DROP INDEX IF EXISTS {NEW_INDEX}"))
+                op.execute(
+                    sa.text(
+                        """
+                        CREATE UNIQUE INDEX {name}
+                            ON {table} (type, booking_id)
+                        """.format(name=OLD_CONSTRAINT, table=TABLE_NAME)
+                    )
+                )
+            else:
+                with context.autocommit_block():
+                    op.drop_index(
+                        NEW_INDEX,
+                        table_name=TABLE_NAME,
+                        postgresql_concurrently=True,
+                    )
+
+            if dialect_name != "sqlite":
+                op.create_unique_constraint(
+                    OLD_CONSTRAINT,
+                    TABLE_NAME,
+                    ["type", "booking_id"],
+                )
+            op.drop_column(TABLE_NAME, CANDIDATE_COLUMN)
+    finally:
+        if standalone_conn is not conn:
+            standalone_conn.close()

--- a/backend/migrations/versions/0012_update_slots_candidate_recruiter_index.py
+++ b/backend/migrations/versions/0012_update_slots_candidate_recruiter_index.py
@@ -1,0 +1,110 @@
+from typing import Tuple
+
+import sqlalchemy as sa
+from alembic.operations import Operations
+from alembic.runtime.migration import MigrationContext
+from sqlalchemy.engine import Connection
+
+
+revision = "0012_update_slots_candidate_recruiter_index"
+down_revision = "0011_add_candidate_binding_to_notification_logs"
+branch_labels = None
+depends_on = None
+
+
+TABLE_NAME = "slots"
+INDEX_NAME = "uq_slots_candidate_recruiter_active"
+
+
+def _get_operations(conn: Connection) -> Tuple[Operations, MigrationContext, Connection]:
+    engine = getattr(conn, "engine", None)
+    standalone_conn = engine.connect() if engine is not None else conn
+    if engine is not None and engine.dialect.name == "sqlite" and standalone_conn is not conn:
+        standalone_conn.close()
+        standalone_conn = conn
+    context = MigrationContext.configure(connection=standalone_conn)
+    return Operations(context), context, standalone_conn
+
+
+def upgrade(conn: Connection) -> None:
+    op, context, standalone_conn = _get_operations(conn)
+
+    try:
+        dialect_name = getattr(standalone_conn, "dialect", None)
+        dialect_name = dialect_name.name if dialect_name is not None else ""
+
+        with context.begin_transaction():
+            if dialect_name == "sqlite":
+                op.execute(sa.text(f"DROP INDEX IF EXISTS {INDEX_NAME}"))
+                op.execute(
+                    sa.text(
+                        """
+                        CREATE UNIQUE INDEX {name}
+                            ON {table} (candidate_tg_id, recruiter_id)
+                         WHERE lower(status) IN ('pending','booked','confirmed_by_candidate')
+                        """.format(name=INDEX_NAME, table=TABLE_NAME)
+                    )
+                )
+            else:
+                with context.autocommit_block():
+                    op.drop_index(
+                        INDEX_NAME,
+                        table_name=TABLE_NAME,
+                        postgresql_concurrently=True,
+                    )
+                where_clause = sa.text(
+                    "lower(status) IN ('pending','booked','confirmed_by_candidate')"
+                )
+                with context.autocommit_block():
+                    op.create_index(
+                        INDEX_NAME,
+                        TABLE_NAME,
+                        ["candidate_tg_id", "recruiter_id"],
+                        unique=True,
+                        postgresql_where=where_clause,
+                        postgresql_concurrently=True,
+                    )
+    finally:
+        if standalone_conn is not conn:
+            standalone_conn.close()
+
+
+def downgrade(conn: Connection) -> None:  # pragma: no cover - rollback helper
+    op, context, standalone_conn = _get_operations(conn)
+
+    try:
+        dialect_name = getattr(standalone_conn, "dialect", None)
+        dialect_name = dialect_name.name if dialect_name is not None else ""
+
+        with context.begin_transaction():
+            if dialect_name == "sqlite":
+                op.execute(sa.text(f"DROP INDEX IF EXISTS {INDEX_NAME}"))
+                op.execute(
+                    sa.text(
+                        """
+                        CREATE UNIQUE INDEX {name}
+                            ON {table} (candidate_tg_id, recruiter_id)
+                         WHERE lower(status) IN ('pending','booked')
+                        """.format(name=INDEX_NAME, table=TABLE_NAME)
+                    )
+                )
+            else:
+                with context.autocommit_block():
+                    op.drop_index(
+                        INDEX_NAME,
+                        table_name=TABLE_NAME,
+                        postgresql_concurrently=True,
+                    )
+                where_clause = sa.text("lower(status) IN ('pending','booked')")
+                with context.autocommit_block():
+                    op.create_index(
+                        INDEX_NAME,
+                        TABLE_NAME,
+                        ["candidate_tg_id", "recruiter_id"],
+                        unique=True,
+                        postgresql_where=where_clause,
+                        postgresql_concurrently=True,
+                    )
+    finally:
+        if standalone_conn is not conn:
+            standalone_conn.close()

--- a/tests/audit_failing_tests/test_double_booking.py
+++ b/tests/audit_failing_tests/test_double_booking.py
@@ -67,4 +67,66 @@ async def test_confirmed_candidate_cannot_double_book_same_recruiter():
         expected_city_id=city.id,
     )
 
-    assert second_reservation.status != "reserved", "Кандидат с подтверждённым слотом не должен бронировать повторно"
+    assert (
+        second_reservation.status == "duplicate_candidate"
+    ), "Кандидат с подтверждённым слотом не должен бронировать повторно"
+
+
+@pytest.mark.asyncio
+async def test_confirmed_candidate_can_book_other_recruiter():
+    async with async_session() as session:
+        recruiter_a = models.Recruiter(name="Алексей", tz="Europe/Moscow", active=True)
+        recruiter_b = models.Recruiter(name="Сергей", tz="Europe/Moscow", active=True)
+        city = models.City(name="Самара", tz="Europe/Moscow", active=True)
+        session.add_all([recruiter_a, recruiter_b, city])
+        await session.commit()
+        await session.refresh(recruiter_a)
+        await session.refresh(recruiter_b)
+        await session.refresh(city)
+
+        slot_one = models.Slot(
+            recruiter_id=recruiter_a.id,
+            city_id=city.id,
+            start_utc=datetime.now(timezone.utc) + timedelta(hours=10),
+            status=SlotStatus.FREE,
+        )
+        slot_two = models.Slot(
+            recruiter_id=recruiter_b.id,
+            city_id=city.id,
+            start_utc=datetime.now(timezone.utc) + timedelta(hours=12),
+            status=SlotStatus.FREE,
+        )
+        session.add_all([slot_one, slot_two])
+        await session.commit()
+        await session.refresh(slot_one)
+        await session.refresh(slot_two)
+
+        slot_one_id = slot_one.id
+        slot_two_id = slot_two.id
+
+    reservation = await reserve_slot(
+        slot_one_id,
+        candidate_tg_id=777,
+        candidate_fio="Двойник",
+        candidate_tz="Europe/Moscow",
+        candidate_city_id=city.id,
+        expected_recruiter_id=recruiter_a.id,
+        expected_city_id=city.id,
+    )
+    assert reservation.status == "reserved"
+
+    await approve_slot(slot_one_id)
+    confirm_result = await confirm_slot_by_candidate(slot_one_id)
+    assert confirm_result.status == "confirmed"
+
+    second_reservation = await reserve_slot(
+        slot_two_id,
+        candidate_tg_id=777,
+        candidate_fio="Двойник",
+        candidate_tz="Europe/Moscow",
+        candidate_city_id=city.id,
+        expected_recruiter_id=recruiter_b.id,
+        expected_city_id=city.id,
+    )
+
+    assert second_reservation.status == "reserved"


### PR DESCRIPTION
## Summary
- add migrations and model updates to bind notification logs to candidates and clean up legacy records when slots are released
- enforce recruiter/candidate booking checks for confirmed slots and expose confirmed counts in the admin UI
- update bot logic and tests to ensure notifications/reminders are candidate scoped and add coverage for reuse and double booking scenarios

## Testing
- `pytest tests/audit_failing_tests/test_notification_logs.py tests/audit_failing_tests/test_double_booking.py`
- `pytest tests/test_bot_confirmation_flows.py`
- `pytest tests/services/test_dashboard_and_slots.py`


------
https://chatgpt.com/codex/tasks/task_e_68e381e26d5c83339aeee0c28a9d7840