### PR TITLE
Remove candidate message preview from recruiter confirmation

### DIFF
--- a/backend/apps/bot/services.py
+++ b/backend/apps/bot/services.py
@@ -1905,13 +1905,6 @@ async def handle_approve_slot(callback: CallbackQuery) -> None:
         ]
         if candidate_city:
             summary_parts.append(f"📍 {html.escape(candidate_city)}")
-        summary_parts.extend(
-            [
-                "",
-                "<b>Текст сообщения:</b>",
-                f"<blockquote>{message_text}</blockquote>",
-            ]
-        )
         summary_text = "\n".join(summary_parts)
 
         await safe_edit_text_or_caption(callback.message, summary_text)


### PR DESCRIPTION
## Summary
- stop echoing the candidate notification text back to the recruiter after slot approval

## Testing
- pytest tests/test_bot_confirmation_flows.py::test_handle_approve_slot_sends_message -q *(fails: missing optional dependency `sqlalchemy` in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e38f38262c833395d83ee5139aa467