### PR TITLE
Implement region-aware local time handling for slots

### DIFF
--- a/backend/apps/admin_ui/app.py
+++ b/backend/apps/admin_ui/app.py
@@ -12,6 +12,7 @@ from backend.apps.admin_ui.routers import (
     candidates,
     cities,
     dashboard,
+    regions,
     questions,
     recruiters,
     slots,
@@ -58,6 +59,7 @@ def create_app() -> FastAPI:
     app.include_router(candidates.router, dependencies=[Depends(require_admin)])
     app.include_router(recruiters.router, dependencies=[Depends(require_admin)])
     app.include_router(cities.router, dependencies=[Depends(require_admin)])
+    app.include_router(regions.router, dependencies=[Depends(require_admin)])
     app.include_router(templates.router, dependencies=[Depends(require_admin)])
     app.include_router(questions.router, dependencies=[Depends(require_admin)])
     app.include_router(api.router, dependencies=[Depends(require_admin)])

--- a/backend/apps/admin_ui/routers/__init__.py
+++ b/backend/apps/admin_ui/routers/__init__.py
@@ -1,16 +1,17 @@
 """Exports for admin UI routers."""
 
-from . import (
+from . import (  # noqa: F401
     api,
     candidates,
     cities,
     dashboard,
     recruiters,
+    regions,
     slots,
     system,
     templates,
     questions,
-)  # noqa: F401
+)
 
 __all__ = [
     "api",
@@ -18,6 +19,7 @@ __all__ = [
     "cities",
     "dashboard",
     "recruiters",
+    "regions",
     "slots",
     "system",
     "templates",

--- a/backend/apps/admin_ui/routers/regions.py
+++ b/backend/apps/admin_ui/routers/regions.py
@@ -1,0 +1,20 @@
+from fastapi import APIRouter, HTTPException
+
+from backend.apps.admin_ui.utils import validate_timezone_name
+from backend.core.db import async_session
+from backend.domain.models import City
+
+router = APIRouter(prefix="/regions", tags=["regions"])
+
+
+@router.get("/{region_id}/timezone")
+async def region_timezone(region_id: int):
+    async with async_session() as session:
+        city = await session.get(City, region_id)
+        if city is None:
+            raise HTTPException(status_code=404, detail="Region not found")
+        try:
+            tz_name = validate_timezone_name(city.tz)
+        except ValueError:
+            raise HTTPException(status_code=422, detail="Region timezone is invalid")
+    return {"timezone": tz_name}

--- a/backend/apps/admin_ui/routers/slots.py
+++ b/backend/apps/admin_ui/routers/slots.py
@@ -4,9 +4,11 @@ import hmac
 import json
 from typing import Dict, Optional
 
-from fastapi import APIRouter, BackgroundTasks, Depends, Form, Query, Request
+from datetime import datetime
+
+from fastapi import APIRouter, BackgroundTasks, Depends, Form, Query, Request, HTTPException, status
 from fastapi.responses import HTMLResponse, RedirectResponse, JSONResponse
-from pydantic import BaseModel
+from pydantic import BaseModel, Field, field_validator, ConfigDict
 
 from backend.apps.admin_ui.config import templates
 from backend.apps.admin_ui.services.bot_service import BotService, provide_bot_service
@@ -23,8 +25,18 @@ from backend.apps.admin_ui.services.slots import (
     reschedule_slot_booking,
     reject_slot_booking,
 )
-from backend.apps.admin_ui.utils import norm_status, parse_optional_int, status_filter
+from backend.apps.admin_ui.utils import (
+    ensure_utc,
+    local_naive_to_utc,
+    norm_status,
+    parse_optional_int,
+    status_filter,
+    utc_to_local_naive,
+    validate_timezone_name,
+)
+from backend.core.db import async_session
 from backend.core.settings import get_settings
+from backend.domain.models import City, Recruiter, Slot, SlotStatus
 
 router = APIRouter(prefix="/slots", tags=["slots"])
 
@@ -66,6 +78,65 @@ def _set_flash(response: RedirectResponse, status: str, message: str) -> None:
         secure=_SETTINGS.session_cookie_secure,
         samesite=_SETTINGS.session_cookie_samesite,
     )
+
+
+def _slot_payload(slot: Slot, tz_name: Optional[str]) -> Dict[str, object]:
+    starts_at_local: Optional[datetime] = None
+    if tz_name:
+        try:
+            starts_at_local = utc_to_local_naive(slot.start_utc, tz_name)
+        except ValueError:
+            starts_at_local = None
+    return {
+        "id": slot.id,
+        "recruiter_id": slot.recruiter_id,
+        "city_id": slot.city_id,
+        "region_id": slot.city_id,
+        "starts_at_utc": ensure_utc(slot.start_utc),
+        "starts_at_local": starts_at_local,
+        "duration_min": slot.duration_min,
+        "status": norm_status(slot.status),
+    }
+
+
+class SlotPayloadBase(BaseModel):
+    region_id: Optional[int] = Field(default=None, alias="city_id")
+    starts_at_local: Optional[datetime] = None
+    starts_at_utc: Optional[datetime] = None
+    duration_min: Optional[int] = Field(default=None, ge=1)
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    @field_validator("starts_at_local", mode="before")
+    @classmethod
+    def _parse_local(cls, value: object) -> Optional[datetime]:
+        if value in (None, "", b"", []):
+            return None
+        if isinstance(value, str):
+            try:
+                return datetime.fromisoformat(value)
+            except ValueError as exc:
+                raise ValueError("starts_at_local must be ISO8601 without timezone") from exc
+        if isinstance(value, datetime):
+            return value
+        raise ValueError("starts_at_local must be a datetime string")
+
+    @field_validator("starts_at_local")
+    @classmethod
+    def _ensure_naive(cls, value: Optional[datetime]) -> Optional[datetime]:
+        if value is not None and value.tzinfo is not None:
+            raise ValueError("starts_at_local must not include timezone information")
+        return value
+
+
+class SlotCreatePayload(SlotPayloadBase):
+    recruiter_id: int
+    region_id: int = Field(..., alias="city_id")
+
+
+class SlotUpdatePayload(SlotPayloadBase):
+    recruiter_id: Optional[int] = None
+    region_id: int = Field(..., alias="city_id")
 
 
 @router.get("", response_class=HTMLResponse)
@@ -143,7 +214,7 @@ async def slots_create(
     date: str = Form(...),
     time: str = Form(...),
 ):
-    ok = await create_slot(recruiter_id, date, time, city_id=city_id)
+    ok, _ = await create_slot(recruiter_id, date, time, city_id=city_id)
     redirect = "/slots" if ok else "/slots/new"
     response = RedirectResponse(url=redirect, status_code=303)
     if ok:
@@ -191,6 +262,138 @@ async def slots_bulk_create(
         _set_flash(response, "success", f"Создано {created} слот(ов).")
 
     return response
+
+
+@router.post("", status_code=status.HTTP_201_CREATED)
+async def slots_api_create(payload: SlotCreatePayload):
+    async with async_session() as session:
+        recruiter = await session.get(Recruiter, payload.recruiter_id)
+        if recruiter is None:
+            raise HTTPException(status_code=404, detail="Recruiter not found")
+
+        region_id = payload.region_id
+        if region_id is None:
+            raise HTTPException(status_code=422, detail="region_id is required")
+
+        city = await session.get(City, region_id)
+        if city is None:
+            raise HTTPException(status_code=422, detail="Region not found")
+        if city.responsible_recruiter_id != recruiter.id:
+            raise HTTPException(
+                status_code=422,
+                detail="Region is not assigned to the recruiter",
+            )
+
+        try:
+            tz_name = validate_timezone_name(city.tz)
+        except ValueError:
+            raise HTTPException(
+                status_code=422,
+                detail="Region timezone is invalid",
+            )
+
+        if payload.starts_at_local is not None:
+            start_utc = local_naive_to_utc(payload.starts_at_local, tz_name)
+        elif payload.starts_at_utc is not None:
+            start_utc = ensure_utc(payload.starts_at_utc)
+        else:
+            raise HTTPException(
+                status_code=422,
+                detail="starts_at_local is required",
+            )
+
+        status_free = getattr(SlotStatus, "FREE", "FREE")
+        if hasattr(status_free, "value"):
+            status_free = status_free.value
+
+        slot = Slot(
+            recruiter_id=recruiter.id,
+            city_id=city.id,
+            start_utc=start_utc,
+            status=status_free,
+        )
+        if payload.duration_min is not None:
+            slot.duration_min = max(int(payload.duration_min), 1)
+
+        session.add(slot)
+        await session.commit()
+        await session.refresh(slot)
+
+    return _slot_payload(slot, tz_name)
+
+
+@router.put("/{slot_id}")
+async def slots_api_update(slot_id: int, payload: SlotUpdatePayload):
+    async with async_session() as session:
+        slot = await session.get(Slot, slot_id)
+        if slot is None:
+            raise HTTPException(status_code=404, detail="Slot not found")
+
+        recruiter_id = payload.recruiter_id or slot.recruiter_id
+        recruiter = await session.get(Recruiter, recruiter_id)
+        if recruiter is None:
+            raise HTTPException(status_code=404, detail="Recruiter not found")
+
+        region_id = payload.region_id
+        if region_id is None:
+            raise HTTPException(status_code=422, detail="region_id is required")
+
+        city = await session.get(City, region_id)
+        if city is None:
+            raise HTTPException(status_code=422, detail="Region not found")
+        if city.responsible_recruiter_id != recruiter.id:
+            raise HTTPException(
+                status_code=422,
+                detail="Region is not assigned to the recruiter",
+            )
+
+        try:
+            tz_name = validate_timezone_name(city.tz)
+        except ValueError:
+            raise HTTPException(
+                status_code=422,
+                detail="Region timezone is invalid",
+            )
+
+        if payload.starts_at_local is not None:
+            start_utc = local_naive_to_utc(payload.starts_at_local, tz_name)
+        elif payload.starts_at_utc is not None:
+            start_utc = ensure_utc(payload.starts_at_utc)
+        else:
+            raise HTTPException(
+                status_code=422,
+                detail="starts_at_local is required",
+            )
+
+        slot.recruiter_id = recruiter.id
+        slot.city_id = city.id
+        slot.start_utc = start_utc
+        if payload.duration_min is not None:
+            slot.duration_min = max(int(payload.duration_min), 1)
+
+        await session.commit()
+        await session.refresh(slot)
+
+    return _slot_payload(slot, tz_name)
+
+
+@router.get("/{slot_id}")
+async def slots_api_detail(slot_id: int):
+    async with async_session() as session:
+        slot = await session.get(Slot, slot_id)
+        if slot is None:
+            raise HTTPException(status_code=404, detail="Slot not found")
+
+        tz_name: Optional[str] = None
+        if slot.city_id is not None:
+            city = await session.get(City, slot.city_id)
+            if city is not None:
+                try:
+                    tz_name = validate_timezone_name(city.tz)
+                except ValueError:
+                    tz_name = None
+
+    return _slot_payload(slot, tz_name)
 
 
 @router.post("/{slot_id}/delete")

--- a/backend/apps/admin_ui/services/slots.py
+++ b/backend/apps/admin_ui/services/slots.py
@@ -30,10 +30,11 @@ try:  # pragma: no cover - optional dependency during tests
 except Exception:  # pragma: no cover - safe fallback when bot package unavailable
     get_reminder_service = None  # type: ignore[assignment]
 from backend.apps.admin_ui.utils import (
+    local_naive_to_utc,
     norm_status,
     paginate,
-    recruiter_time_to_utc,
     status_to_db,
+    validate_timezone_name,
 )
 from backend.core.db import async_session
 from backend.core.settings import get_settings
@@ -152,30 +153,39 @@ async def create_slot(
     time: str,
     *,
     city_id: int,
-) -> bool:
+) -> Tuple[bool, Optional[Slot]]:
+    try:
+        local_dt = datetime.fromisoformat(f"{date}T{time}")
+    except ValueError:
+        return False, None
+
     async with async_session() as session:
         recruiter = await session.get(Recruiter, recruiter_id)
         if not recruiter:
-            return False
+            return False, None
         city = await session.get(City, city_id)
         if not city or city.responsible_recruiter_id != recruiter_id:
-            return False
-        dt_utc = recruiter_time_to_utc(date, time, getattr(recruiter, "tz", None))
-        if not dt_utc:
-            return False
+            return False, None
+        try:
+            tz_name = validate_timezone_name(city.tz)
+        except ValueError:
+            return False, None
+
+        dt_utc = local_naive_to_utc(local_dt, tz_name)
         status_free = getattr(SlotStatus, "FREE", "FREE")
         if hasattr(status_free, "value"):
             status_free = status_free.value
-        session.add(
-            Slot(
-                recruiter_id=recruiter_id,
-                city_id=city_id,
-                start_utc=dt_utc,
-                status=status_free,
-            )
+
+        slot = Slot(
+            recruiter_id=recruiter_id,
+            city_id=city_id,
+            start_utc=dt_utc,
+            status=status_free,
         )
+        session.add(slot)
         await session.commit()
-        return True
+        await session.refresh(slot)
+        return True, slot
 
 
 async def delete_slot(
@@ -674,7 +684,10 @@ async def bulk_create_slots(
         break_start_minutes = pause_start.hour * 60 + pause_start.minute
         break_end_minutes = pause_end.hour * 60 + pause_end.minute
 
-        tz = getattr(recruiter, "tz", None)
+        try:
+            tz = validate_timezone_name(city.tz)
+        except ValueError:
+            return 0, "Некорректный часовой пояс региона"
 
         planned_pairs: List[Tuple[datetime, datetime]] = []  # (original, normalized)
         planned_norms = set()
@@ -693,11 +706,13 @@ async def bulk_create_slots(
 
                     hours, minutes = divmod(current_minutes, 60)
                     time_str = f"{hours:02d}:{minutes:02d}"
-                    dt_utc = recruiter_time_to_utc(
-                        current_date.isoformat(), time_str, tz
-                    )
-                    if not dt_utc:
-                        return 0, "Не удалось преобразовать время в UTC"
+                    try:
+                        dt_local = datetime.fromisoformat(
+                            f"{current_date.isoformat()}T{time_str}"
+                        )
+                    except ValueError:
+                        return 0, "Некорректное время"
+                    dt_utc = local_naive_to_utc(dt_local, tz)
                     norm_dt = _normalize_utc(dt_utc)
                     if norm_dt not in planned_norms:
                         planned_norms.add(norm_dt)

--- a/backend/apps/admin_ui/templates/slots_new.html
+++ b/backend/apps/admin_ui/templates/slots_new.html
@@ -73,7 +73,11 @@
           {% for item in recruiters %}
             {% set r = item.rec %}
             {% for city in item.cities %}
-              <option value="{{ city.id }}" data-rec="{{ r.id }}">{{ city.name }} ({{ city.tz or "Europe/Moscow" }})</option>
+              {% set city_tz = city.tz or 'Europe/Moscow' %}
+              <option value="{{ city.id }}"
+                      data-rec="{{ r.id }}"
+                      data-tz="{{ city_tz }}"
+                      data-tz-label="{{ tz_display(city_tz) }}">{{ city.name }} ({{ city_tz }})</option>
             {% endfor %}
           {% endfor %}
         </select>
@@ -102,9 +106,12 @@
             <button class="btn btn--ghost btn--sm" type="button" data-time="13:00">13:00</button>
             <button class="btn btn--ghost btn--sm" type="button" data-time="15:00">15:00</button>
           </div>
+          <p class="form-note" id="time_hint_one">Время указывается по региону: —</p>
         {% endcall %}
       </div>
     {% endcall %}
+
+    <input type="hidden" name="starts_at_local" id="starts_at_local_one" value="">
 
     <div class="preview-panel" id="preview-one" aria-live="polite">
       <b>Превью</b><br>
@@ -146,7 +153,11 @@
           {% for item in recruiters %}
             {% set r = item.rec %}
             {% for city in item.cities %}
-              <option value="{{ city.id }}" data-rec="{{ r.id }}">{{ city.name }} ({{ city.tz or "Europe/Moscow" }})</option>
+              {% set city_tz = city.tz or 'Europe/Moscow' %}
+              <option value="{{ city.id }}"
+                      data-rec="{{ r.id }}"
+                      data-tz="{{ city_tz }}"
+                      data-tz-label="{{ tz_display(city_tz) }}">{{ city.name }} ({{ city_tz }})</option>
             {% endfor %}
           {% endfor %}
         </select>
@@ -346,18 +357,6 @@
 
   function toISOZ(d){ if(!d) return ''; const s = d.toISOString(); return s.replace('.000',''); }
 
-  const nowChip = $('#now_text');
-  const nowChipWrap = $('#now_chip');
-  function updateNowChip(){
-    const selector = $('#recruiter_id');
-    const hasSelection = !!(selector && selector.value);
-    const tz = hasSelection ? currentTZ(selector) : null;
-    nowChip.textContent = tz ? tzNowText(tz) : '—:—';
-    if (nowChipWrap){
-      nowChipWrap.title = hasSelection ? currentTZLabel(selector) : 'Выберите рекрутёра';
-    }
-  }
-
   const selOne = $('#recruiter_id');
   const cityOne = $('#city_id');
   const cityHintOne = $('#city_hint_one');
@@ -367,24 +366,49 @@
   const prevOne= $('#preview-one');
   const btnOne = $('#btn-create-one');
   const offsetText = $('#offset_text');
+  const timeHintOne = $('#time_hint_one');
+  const startsAtLocalOne = $('#starts_at_local_one');
 
-  function currentTZ(selectEl){
-    const el = selectEl || selOne;
-    const opt = el ? el.selectedOptions[0] : null;
-    return opt ? (opt.getAttribute('data-tz') || 'Europe/Moscow') : 'Europe/Moscow';
+  function selectedOption(selectEl){
+    if (!selectEl) return null;
+    const opt = selectEl.selectedOptions[0];
+    if (!opt || opt.disabled || opt.hidden) return null;
+    return opt;
   }
 
-  function currentTZLabel(selectEl){
-    const el = selectEl || selOne;
-    const opt = el ? el.selectedOptions[0] : null;
+  function optionTZ(opt){
+    if (!opt) return null;
+    const tz = (opt.getAttribute('data-tz') || '').trim();
+    return tz || null;
+  }
+
+  function currentRegionTZ(selectEl){
+    const opt = selectedOption(selectEl || cityOne);
+    return optionTZ(opt) || 'Europe/Moscow';
+  }
+
+  function currentRegionLabel(selectEl){
+    const opt = selectedOption(selectEl || cityOne);
     if (!opt) return '—';
-    const raw = opt.getAttribute('data-tz-label') || opt.textContent;
-    if (raw && raw.trim()) return raw.trim();
-    const tz = opt.getAttribute('data-tz');
-    if (tz && tz.trim()){
-      return `${tz.trim()} (UTC${getOffsetLabel(tz.trim(), new Date())})`;
+    const raw = (opt.getAttribute('data-tz-label') || opt.textContent || '').trim();
+    if (raw) return raw;
+    const tz = optionTZ(opt);
+    if (tz){
+      return `${tz} (UTC${getOffsetLabel(tz, new Date())})`;
     }
     return '—';
+  }
+
+  const nowChip = $('#now_text');
+  const nowChipWrap = $('#now_chip');
+  function updateNowChip(){
+    const selector = cityOne || $('#city_id');
+    const hasSelection = !!selectedOption(selector);
+    const tz = hasSelection ? currentRegionTZ(selector) : null;
+    nowChip.textContent = tz ? tzNowText(tz) : '—:—';
+    if (nowChipWrap){
+      nowChipWrap.title = hasSelection ? currentRegionLabel(selector) : 'Выберите регион';
+    }
   }
 
   function updateCityOptions(recSelect, citySelect, hintEl){
@@ -435,21 +459,28 @@
 
   function updateOne(){
     const hasCities = updateCityOptions(selOne, cityOne, cityHintOne);
-    const tz = currentTZ(selOne);
-    const hasRecruiter = !!selOne?.value;
-    const tzLabel = hasRecruiter ? currentTZLabel(selOne) : '—';
+    const regionSelected = !!selectedOption(cityOne);
+    const tz = regionSelected ? currentRegionTZ(cityOne) : 'Europe/Moscow';
+    const tzLabel = regionSelected ? currentRegionLabel(cityOne) : '—';
     tzOne.textContent = `Регион: ${tzLabel}`;
-    offsetText.textContent = hasRecruiter ? getOffsetLabel(tz, new Date()) : '±0';
+    if (timeHintOne){
+      timeHintOne.textContent = `Время указывается по региону: ${tzLabel}`;
+    }
+    offsetText.textContent = regionSelected ? getOffsetLabel(tz, new Date()) : '±0';
     updateNowChip();
 
     const d = dateOne.value, t = timeOne.value;
     const cityVal = cityOne ? cityOne.value : '';
     if (cityOne) storageSet(LS.cityOne, cityVal || '');
-    const ready = !!(selOne.value && hasCities && cityVal && d && t);
+    const ready = !!(selOne.value && hasCities && regionSelected && d && t);
     btnOne.disabled = !ready;
 
+    if (startsAtLocalOne){
+      startsAtLocalOne.value = ready ? `${d}T${t}` : '';
+    }
+
     if (!ready){
-      prevOne.innerHTML = '<b>Превью</b><br>Укажите рекрутёра, дату и время — покажем UTC.';
+      prevOne.innerHTML = '<b>Превью</b><br>Укажите рекрутёра, регион, дату и время — покажем UTC.';
       return;
     }
     const localIso = `${d}T${t}:00`;
@@ -497,7 +528,7 @@
   $$('#form-one [data-time]').forEach(btn=>{
     btn.addEventListener('click', ()=>{
       const kind = btn.getAttribute('data-time');
-      const tz = currentTZ(selOne);
+      const tz = currentRegionTZ(cityOne);
       let base = new Date(new Date().toLocaleString('en-US', { timeZone: tz }));
       if (dateOne.value){ base = new Date(`${dateOne.value}T${timeOne.value||'09:00'}:00`); }
       if (kind==='next30') base = new Date(base.getTime() + 30*60000);
@@ -533,6 +564,13 @@
   timeOne?.addEventListener('input', updateOne);
   cityOne?.addEventListener('change', ()=>{
     storageSet(LS.cityOne, cityOne.value||'');
+    if (timeOne && timeOne.value){
+      timeOne.value = '';
+      storageSet(LS.time, '');
+    }
+    if (startsAtLocalOne){
+      startsAtLocalOne.value = '';
+    }
     updateOne();
   });
 
@@ -629,14 +667,15 @@
   function updateBulk(){
     const hasCities = updateCityOptions(selBulk, cityBulk, cityHintBulk);
     const hasRecruiter = !!selBulk?.value;
-    const tz = currentTZ(selBulk);
-    const tzLabel = hasRecruiter ? currentTZLabel(selBulk) : '—';
+    const regionSelected = !!selectedOption(cityBulk);
+    const tz = regionSelected ? currentRegionTZ(cityBulk) : 'Europe/Moscow';
+    const tzLabel = regionSelected ? currentRegionLabel(cityBulk) : '—';
     tzBulk.textContent = `Регион: ${tzLabel}`;
 
     const s = sd.value, e = ed.value;
     const cityVal = cityBulk ? cityBulk.value : '';
     if (cityBulk) storageSet(LS.cityBulk, cityVal || '');
-    const ready = !!(selBulk.value && hasCities && cityVal && s && e);
+    const ready = !!(selBulk.value && hasCities && regionSelected && s && e);
     btnBulk.disabled = !ready;
 
     const st = hid.start.value, en = hid.end.value, bs = hid.bstart.value, be = hid.bend.value, step = parseInt(hid.step.value||'30',10);

--- a/backend/domain/models.py
+++ b/backend/domain/models.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timezone, date
 from typing import Optional, List
+from zoneinfo import ZoneInfo
 
 from sqlalchemy import (
     String,
@@ -58,6 +59,17 @@ class City(Base):
 
     def __repr__(self) -> str:
         return f"<City {self.name} ({self.tz})>"
+
+    @validates("tz")
+    def _validate_timezone(self, _key, value: Optional[str]) -> str:
+        candidate = (value or "").strip()
+        if not candidate:
+            raise ValueError("Timezone must be provided")
+        try:
+            ZoneInfo(candidate)
+        except Exception as exc:  # pragma: no cover - defensive
+            raise ValueError(f"Invalid timezone: {candidate}") from exc
+        return candidate
 
 
 class Template(Base):

--- a/tests/services/test_dashboard_and_slots.py
+++ b/tests/services/test_dashboard_and_slots.py
@@ -32,7 +32,7 @@ async def test_dashboard_and_slot_listing():
         await session.commit()
         await session.refresh(city)
 
-    created = await create_slot(
+    created, _ = await create_slot(
         recruiter_id=recruiter.id,
         date=str(date.today()),
         time="10:00",

--- a/tests/services/test_slots_bulk.py
+++ b/tests/services/test_slots_bulk.py
@@ -1,10 +1,10 @@
 import pytest
-from datetime import date, timezone
+from datetime import date, datetime, timezone
 
 from sqlalchemy import select
 
 from backend.apps.admin_ui.services.slots import bulk_create_slots
-from backend.apps.admin_ui.utils import recruiter_time_to_utc
+from backend.apps.admin_ui.utils import local_naive_to_utc
 from backend.core.db import async_session
 from backend.domain import models
 
@@ -85,9 +85,9 @@ async def test_bulk_create_slots_creates_unique_series():
         stored = {slot.start_utc for slot in stored_slots}
 
     expected = {
-        recruiter_time_to_utc(start.isoformat(), "10:00", recruiter.tz),
-        recruiter_time_to_utc(start.isoformat(), "10:30", recruiter.tz),
-        recruiter_time_to_utc(start.isoformat(), "11:00", recruiter.tz),
+        local_naive_to_utc(datetime.fromisoformat(f"{start.isoformat()}T10:00"), city.tz),
+        local_naive_to_utc(datetime.fromisoformat(f"{start.isoformat()}T10:30"), city.tz),
+        local_naive_to_utc(datetime.fromisoformat(f"{start.isoformat()}T11:00"), city.tz),
     }
 
     def _as_utc(dt):

--- a/tests/services/test_slots_delete.py
+++ b/tests/services/test_slots_delete.py
@@ -29,7 +29,12 @@ async def test_delete_slot_allows_free_and_pending_blocks_booked():
     recruiter_id, city_id = await _setup_recruiter_with_city()
 
     # FREE slot via public API helper
-    created = await create_slot(recruiter_id, datetime.now().date().isoformat(), "09:00", city_id=city_id)
+    created, _ = await create_slot(
+        recruiter_id,
+        datetime.now().date().isoformat(),
+        "09:00",
+        city_id=city_id,
+    )
     assert created is True
 
     async with async_session() as session:

--- a/tests/test_slots_api_tz.py
+++ b/tests/test_slots_api_tz.py
@@ -1,0 +1,171 @@
+import asyncio
+import os
+from datetime import datetime, timezone
+from typing import Any, Dict
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import update
+
+os.environ.setdefault("ADMIN_USER", "admin")
+os.environ.setdefault("ADMIN_PASSWORD", "secret")
+
+from backend.apps.admin_ui.app import create_app
+from backend.core.db import async_session
+from backend.core.settings import get_settings
+from backend.domain import models
+
+
+async def _async_request(app, method: str, path: str, **kwargs: Dict[str, Any]):
+    def _call() -> Any:
+        with TestClient(app) as client:
+            settings = get_settings()
+            if settings.admin_username and settings.admin_password:
+                client.auth = (settings.admin_username, settings.admin_password)
+            return client.request(method, path, **kwargs)
+
+    return await asyncio.to_thread(_call)
+
+
+async def _create_recruiter_and_city(name: str, tz: str) -> Dict[str, int]:
+    async with async_session() as session:
+        recruiter = models.Recruiter(name=f"{name} Recruiter", tz="Europe/Moscow", active=True)
+        city = models.City(name=f"{name} City", tz=tz, active=True)
+        session.add_all([recruiter, city])
+        await session.commit()
+        await session.refresh(recruiter)
+        await session.refresh(city)
+        city.responsible_recruiter_id = recruiter.id
+        await session.commit()
+        await session.refresh(city)
+        return {"recruiter_id": recruiter.id, "city_id": city.id}
+
+
+@pytest.mark.asyncio
+async def test_post_slot_uses_region_timezone_moscow():
+    ids = await _create_recruiter_and_city("Moscow", "Europe/Moscow")
+    app = create_app()
+
+    response = await _async_request(
+        app,
+        "post",
+        "/slots",
+        json={
+            "recruiter_id": ids["recruiter_id"],
+            "region_id": ids["city_id"],
+            "starts_at_local": "2025-10-06T10:00",
+        },
+    )
+    assert response.status_code == 201
+    payload = response.json()
+    assert payload["starts_at_utc"].startswith("2025-10-06T07:00:00")
+
+    async with async_session() as session:
+        slot = await session.get(models.Slot, payload["id"])
+        assert slot is not None
+        assert slot.start_utc.astimezone(timezone.utc) == datetime(2025, 10, 6, 7, 0, tzinfo=timezone.utc)
+
+
+@pytest.mark.asyncio
+async def test_post_slot_uses_region_timezone_novosibirsk():
+    ids = await _create_recruiter_and_city("Novosibirsk", "Asia/Novosibirsk")
+    app = create_app()
+
+    response = await _async_request(
+        app,
+        "post",
+        "/slots",
+        json={
+            "recruiter_id": ids["recruiter_id"],
+            "region_id": ids["city_id"],
+            "starts_at_local": "2025-10-06T10:00",
+        },
+    )
+    assert response.status_code == 201
+    payload = response.json()
+    assert payload["starts_at_utc"].startswith("2025-10-06T03:00:00")
+
+    async with async_session() as session:
+        slot = await session.get(models.Slot, payload["id"])
+        assert slot is not None
+        assert slot.start_utc.astimezone(timezone.utc) == datetime(2025, 10, 6, 3, 0, tzinfo=timezone.utc)
+
+
+@pytest.mark.asyncio
+async def test_get_slot_returns_local_time():
+    ids = await _create_recruiter_and_city("LocalView", "Asia/Novosibirsk")
+    async with async_session() as session:
+        slot = models.Slot(
+            recruiter_id=ids["recruiter_id"],
+            city_id=ids["city_id"],
+            start_utc=datetime(2025, 10, 6, 3, 0, tzinfo=timezone.utc),
+            status=models.SlotStatus.FREE,
+        )
+        session.add(slot)
+        await session.commit()
+        await session.refresh(slot)
+        slot_id = slot.id
+
+    app = create_app()
+    response = await _async_request(app, "get", f"/slots/{slot_id}")
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["starts_at_local"].startswith("2025-10-06T10:00:00")
+
+
+@pytest.mark.asyncio
+async def test_post_requires_region_and_valid_timezone():
+    ids = await _create_recruiter_and_city("Broken", "Europe/Moscow")
+    app = create_app()
+
+    missing_region = await _async_request(
+        app,
+        "post",
+        "/slots",
+        json={
+            "recruiter_id": ids["recruiter_id"],
+            "starts_at_local": "2025-10-06T10:00",
+        },
+    )
+    assert missing_region.status_code == 422
+
+    async with async_session() as session:
+        await session.execute(
+            update(models.City)
+            .where(models.City.id == ids["city_id"])
+            .values(tz="Invalid/Zone")
+        )
+        await session.commit()
+
+    invalid_tz = await _async_request(
+        app,
+        "post",
+        "/slots",
+        json={
+            "recruiter_id": ids["recruiter_id"],
+            "region_id": ids["city_id"],
+            "starts_at_local": "2025-10-06T10:00",
+        },
+    )
+    assert invalid_tz.status_code == 422
+    assert "timezone" in invalid_tz.json().get("detail", "").lower()
+
+
+@pytest.mark.asyncio
+async def test_post_allows_starts_at_utc_for_compatibility():
+    ids = await _create_recruiter_and_city("Compat", "Europe/Moscow")
+    app = create_app()
+
+    response = await _async_request(
+        app,
+        "post",
+        "/slots",
+        json={
+            "recruiter_id": ids["recruiter_id"],
+            "region_id": ids["city_id"],
+            "starts_at_utc": "2025-10-06T07:00:00+00:00",
+        },
+    )
+    assert response.status_code == 201
+    payload = response.json()
+    assert payload["starts_at_utc"].startswith("2025-10-06T07:00:00")

--- a/tests/test_timezones.py
+++ b/tests/test_timezones.py
@@ -1,0 +1,22 @@
+from datetime import datetime, timezone
+
+import pytest
+
+from backend.apps.admin_ui.utils import local_naive_to_utc, utc_to_local_naive
+
+
+@pytest.mark.parametrize(
+    "tz_name,local_hour,expected_hour",
+    [
+        ("Europe/Moscow", 10, 7),
+        ("Asia/Novosibirsk", 10, 3),
+    ],
+)
+def test_local_to_utc_conversion(tz_name: str, local_hour: int, expected_hour: int) -> None:
+    local_dt = datetime(2025, 10, 6, local_hour, 0)
+    utc_dt = local_naive_to_utc(local_dt, tz_name)
+    assert utc_dt.tzinfo is not None
+    assert utc_dt.astimezone(timezone.utc) == datetime(2025, 10, 6, expected_hour, 0, tzinfo=timezone.utc)
+    # Reverse conversion should restore the local time without tzinfo
+    back_local = utc_to_local_naive(utc_dt, tz_name)
+    assert back_local == datetime(2025, 10, 6, local_hour, 0)


### PR DESCRIPTION
## Summary
- add a timezone lookup endpoint for regions and expose region-aware slot payloads that accept `starts_at_local`
- convert slot start times based on the region timezone across services and admin UI flows while keeping UTC storage
- enhance the admin slot form with timezone hints/reset behavior and cover conversions with new API/unit tests

## Testing
- pytest -q tests/test_timezones.py tests/test_slots_api_tz.py

------
https://chatgpt.com/codex/tasks/task_e_68e4206e1ce08333a37ab56ff426b37c